### PR TITLE
Update conversation.user_data for concise summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 - [Advanced Features](#advanced-features)
 - [Additional Features](#additional-features)
 - [Missing Features](#missing-features)
+- [User Data Updates](#user-data-updates)
 
 ## Introduction
 
@@ -236,3 +237,24 @@ AI Runner includes advanced memory optimization settings:
 ### Command-line Arguments
 - `--clear-window-settings`: Resets UI settings.
 - `--perform-llm-analysis`: Enables experimental LLM analysis.
+
+---
+
+## User Data Updates
+
+### Overview
+The `conversation.user_data` column has been updated to store concise, one-sentence summaries of user information. This ensures that the data remains relevant and easy to interpret. Additionally, the system avoids updating this column if no meaningful information is available.
+
+### Key Changes
+- **Concise Summaries**: The `conversation.user_data` column now stores brief summaries instead of verbose descriptions.
+- **Update Conditions**: Updates to the column are skipped if no meaningful information is extracted.
+
+### Testing
+To verify these changes, unit tests have been added to ensure:
+1. Concise summaries are correctly stored.
+2. No updates occur when no meaningful information is available.
+
+Run the tests using:
+```bash
+python -m unittest discover -s src/airunner/tests
+```

--- a/src/airunner/handlers/llm/agent/agents/base.py
+++ b/src/airunner/handlers/llm/agent/agents/base.py
@@ -1189,7 +1189,7 @@ class BaseAgent(
             concise_summary = response.content.strip().split("\n")[:5]  # Limit to 5 concise summaries
             Conversation.objects.update(
                 self.conversation_id,
-                user_data=concise_summary + (conversation.user_data or []),
+                user_data=concise_summary + (self.conversation.user_data or []),
             )
         else:
             self.logger.info("No meaningful information to update.")

--- a/src/airunner/handlers/llm/agent/agents/base.py
+++ b/src/airunner/handlers/llm/agent/agents/base.py
@@ -63,7 +63,7 @@ class BaseAgent(
     ) -> None:
         self.default_tool_choice: Optional[Union[str, dict]] = default_tool_choice
         self.llm_settings: LLMSettings = llm_settings
-        
+
         self._action: LLMActionType = LLMActionType.NONE
         self._chat_prompt: str = ""
         self._current_tab: Optional[Tab] = None
@@ -90,6 +90,9 @@ class BaseAgent(
         self._complete_response: str = ""
         self._store_user_tool: Optional[FunctionTool] = None
         self._webpage_html: str = ""
+        self.model = None  # Initialize model attribute
+        self.tokenizer = None  # Initialize tokenizer attribute
+
         self.signal_handlers.update({
             SignalCode.DELETE_MESSAGES_AFTER_ID: self.on_delete_messages_after_id
         })
@@ -1174,19 +1177,23 @@ class BaseAgent(
                 ) for message in (messages or [])
             ]
         kwargs = {
-            "input": f"Is there any information we can learn about {self.username} from this conversation?",
+            "input": f"Extract concise, one-sentence summaries of relevant information about {self.username} from this conversation.",
             "chat_history": chat_history
         }
         response = self.update_user_data_tool.call(
             do_not_display=True, 
             **kwargs
         )
-        self.logger.info(f"Updating user with new information")
-        Conversation.objects.update(
-            self.conversation_id,
-            user_data=[response.content] + (conversation.user_data or []),
-        )
-    
+        if response.content.strip():
+            self.logger.info("Updating user with new information")
+            concise_summary = response.content.strip().split("\n")[:5]  # Limit to 5 concise summaries
+            Conversation.objects.update(
+                self.conversation_id,
+                user_data=concise_summary + (conversation.user_data or []),
+            )
+        else:
+            self.logger.info("No meaningful information to update.")
+
     def _summarize_conversation(self):
         if (
             not self.llm_settings.perform_conversation_summary or

--- a/src/airunner/tests/test_llm_settings.py
+++ b/src/airunner/tests/test_llm_settings.py
@@ -1,0 +1,58 @@
+import unittest
+from unittest.mock import MagicMock, patch, PropertyMock
+from airunner.handlers.llm.agent.agents.base import BaseAgent
+from airunner.data.models import Conversation
+
+class TestBaseAgentUpdateUserData(unittest.TestCase):
+
+    @patch('airunner.handlers.llm.agent.agents.base.BaseAgent.update_user_data_tool', new_callable=PropertyMock)
+    @patch('airunner.handlers.llm.agent.agents.base.BaseAgent.chat_engine', new_callable=PropertyMock)
+    @patch('airunner.handlers.llm.agent.agents.base.BaseAgent.username', new_callable=PropertyMock)
+    @patch('airunner.handlers.llm.agent.agents.base.Conversation.objects.update')
+    def test_update_user_data(self, mock_update, mock_username, mock_chat_engine, mock_update_user_data_tool):
+        # Mock the response from the update_user_data_tool
+        mock_update_user_data_tool.return_value.call.return_value.content = "User likes hiking.\nUser dislikes loud noises."
+        # Mock the username property
+        mock_username.return_value = "TestUser"
+        # Mock the chat_engine property
+        mock_chat_engine.return_value = MagicMock()
+        # Create a mock conversation
+        mock_conversation = MagicMock()
+        mock_conversation.user_data = []
+        
+        # Create an instance of BaseAgent
+        agent = BaseAgent()
+        agent.conversation = mock_conversation
+        # Call the method
+        agent._update_user_data()
+        # Assert the update method was called with concise summaries
+        mock_update.assert_called_once_with(
+            mock_conversation.id,
+            user_data=["User likes hiking.", "User dislikes loud noises."]
+        )
+
+    @patch('airunner.handlers.llm.agent.agents.base.BaseAgent.update_user_data_tool', new_callable=PropertyMock)
+    @patch('airunner.handlers.llm.agent.agents.base.BaseAgent.chat_engine', new_callable=PropertyMock)
+    @patch('airunner.handlers.llm.agent.agents.base.BaseAgent.username', new_callable=PropertyMock)
+    @patch('airunner.handlers.llm.agent.agents.base.Conversation.objects.update')
+    def test_update_user_data_no_meaningful_info(self, mock_update, mock_username, mock_chat_engine, mock_update_user_data_tool):
+        # Mock the response from the update_user_data_tool with no meaningful content
+        mock_update_user_data_tool.return_value.call.return_value.content = ""
+        # Mock the username property
+        mock_username.return_value = "TestUser"
+        # Mock the chat_engine property
+        mock_chat_engine.return_value = MagicMock()
+        # Create a mock conversation
+        mock_conversation = MagicMock()
+        mock_conversation.user_data = []
+        
+        # Create an instance of BaseAgent
+        agent = BaseAgent()
+        agent.conversation = mock_conversation
+        # Call the method
+        agent._update_user_data()
+        # Assert the update method was not called
+        mock_update.assert_not_called()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR updates the  column to store concise, one-sentence summaries of user information. It also ensures that updates are skipped if no meaningful information is available. Unit tests and documentation have been added to verify and explain these changes.