### PR TITLE
chore: Address type hint warnings from llama index

### DIFF
--- a/src/airunner/handlers/llm/agent/agents/base.py
+++ b/src/airunner/handlers/llm/agent/agents/base.py
@@ -79,7 +79,7 @@ class BaseAgent(
             ExternalConditionStoppingCriteria
         ] = None
         self._do_interrupt: bool = False
-        self._llm: Optional[Type[LLM]] = None
+        self._llm: Optional[LLM] = None
         self._conversation: Optional[Conversation] = None
         self._conversation_id: Optional[int] = None
         self._user: Optional[User] = None


### PR DESCRIPTION
# Rationale

resolves https://github.com/Capsize-Games/airunner/issues/1290 by updating the LLM type hints in `src/airunner/handlers/llm/agent/agents/base.py`

from:

```python
self._llm: Optional[Type[LLM]] = None
```

to

```python
self._llm: Optional[LLM] = None
```