### PR TITLE
chore: remove outdated comment from app.py

### DIFF
--- a/src/airunner/app.py
+++ b/src/airunner/app.py
@@ -1,7 +1,3 @@
-################################################################
-# Importing this module sets the Hugging Face environment
-# variables for the application.
-################################################################
 from typing import Optional, Dict
 import os.path
 import sys


### PR DESCRIPTION
This pull request removes an outdated comment from the top of the airunner/src/app.py file, as requested in [#1342](https://github.com/Capsize-Games/airunner/issues/1342).

The removed comment was no longer relevant and could cause confusion. No functional code has been changed — this is a simple cleanup to improve code readability and maintainability.

Changes:
Removed lines 1–4 from airunner/src/app.py

Closes #1342.

### ✅ Checklist

- [x] The comment was removed as requested
- [x] No functional changes were made
- [x] The codebase still runs correctly
- [x] This PR targets the correct branch