### PR TITLE
Improvements to missing Stable Diffusion models UX flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Below is a high-level list of capabilities in AI Runner:
 - **Memory**: 16 GB RAM  
 - **GPU**: NVIDIA RTX 3060 or better
 - **Network**: Broadband (used to download models)  
-- **Storage**: 22.6 GB
+- **Storage**: 22 GB
 
 ### Recommended Specs
 
@@ -141,7 +141,8 @@ These are the sizes of the various models that power AI Runner.
 | Controlnet (SD 1.5)             | 10.6 GB  |
 | Controlnet (SDXL)             | 320.2 MB  |
 | Safety Checker + Feature Extractor               | 3.2 GB   |
-| SDXL 1.0                | 675 MB   |
+| SD 1.5                | 1.6 MB   |
+| SDXL 1.0                | 6.45 MB   |
 | LLM                     | 5.8 GB   |
 | e5 large (embedding model) | 1.3 GB   |
 | Whisper Tiny            | 155.4 MB |

--- a/src/airunner/gui/windows/main/main_window.py
+++ b/src/airunner/gui/windows/main/main_window.py
@@ -473,7 +473,7 @@ class MainWindow(
 
     @Slot(bool)
     def action_image_generator_toggled(self, val: bool):
-        self.on_toggle_sd(val=val)
+        self.on_toggle_sd({"enabled": val})
 
     @Slot(bool)
     def tts_button_toggled(self, val: bool):
@@ -1022,9 +1022,8 @@ class MainWindow(
             data,
         )
 
-    def on_toggle_sd(self, data: Dict = None, val=None):
-        if val is None:
-            val = not self.application_settings.sd_enabled
+    def on_toggle_sd(self, data: Dict):
+        val = data.get("enabled", False)
         self._update_action_button(
             ModelType.SD,
             self.ui.actionToggle_Stable_Diffusion,
@@ -1419,17 +1418,9 @@ class MainWindow(
         drawing_pad_settings.mask = base64_image
         drawing_pad_settings.save()
 
-    def display_missing_models_error(self):
+    def display_missing_models_error(self, data):
         msg_box = QMessageBox()
         msg_box.setIcon(QMessageBox.Critical)
-        msg_box.setWindowTitle("Error: Missing models")
-        msg_box.setText("You are missing some required models.")
-
-        download_missing_models = msg_box.addButton(
-            "Download missing models", QMessageBox.AcceptRole
-        )
-
+        msg_box.setWindowTitle(data.get("title", "Error: Missing models"))
+        msg_box.setText(data.get("message", "Something went wrong"))
         msg_box.exec()
-
-        if msg_box.clickedButton() == download_missing_models:
-            self.show_setup_wizard()

--- a/src/airunner/handlers/stablediffusion/stable_diffusion_model_manager.py
+++ b/src/airunner/handlers/stablediffusion/stable_diffusion_model_manager.py
@@ -650,10 +650,6 @@ class StableDiffusionModelManager(BaseModelManager):
         """
         # clear the controlnet settings so that we get the latest selected controlnet model
         if not self.controlnet_enabled or self.controlnet_is_loading:
-            if not self.controlnet_enabled:
-                print("controlnet not enabled")
-            if self.controlnet_is_loading:
-                print("controlnet is loading")
             return
         self._controlnet_model = None
         self._controlnet_settings = None


### PR DESCRIPTION
AI Runner does not provide AI art models, so when the application is first loaded and a user clicks "generate" they will get errors and the application will have issues. Additionally if a model goes missing wee don't handle this properly.

This PR addresses those issues by doing checks for Stable Diffusion models before attempting to generate anything. It will show an error message to the user and untoggle the Stable Diffusion button and prevent fatal errors.