### PR TITLE
Fix workflow saving DetachedInstanceError and add robust headless uni…

### DIFF
--- a/src/airunner/gui/widgets/nodegraph/tests/test_workflow_save.py
+++ b/src/airunner/gui/widgets/nodegraph/tests/test_workflow_save.py
@@ -1,0 +1,65 @@
+"""
+Unit tests for workflow save logic in NodeGraphWidget.
+Covers DetachedInstanceError prevention and correct workflow_id usage.
+"""
+import pytest
+from unittest.mock import MagicMock, patch
+from airunner.gui.widgets.nodegraph.node_graph_widget import NodeGraphWidget
+
+class DummyWorkflow:
+    def __init__(self, id):
+        self.id = id
+
+@pytest.fixture
+def widget():
+    # Patch all side-effectful methods so no GUI or DB is touched
+    with patch.object(NodeGraphWidget, "__init__", lambda self: None):
+        w = NodeGraphWidget()
+        w.logger = MagicMock()
+        w.ui = MagicMock()
+        w.ui.variables.variables = []
+        w.graph = MagicMock()
+        return w
+
+def test_save_variables_uses_id_and_never_accesses_orm(widget):
+    """
+    _save_variables should only use workflow.id and never access ORM attributes after session closure.
+    """
+    dummy_workflow = DummyWorkflow(id=42)
+    with patch("airunner.gui.widgets.nodegraph.node_graph_widget.Workflow") as MockWorkflow:
+        MockWorkflow.objects.update = MagicMock()
+        widget._save_variables(dummy_workflow)
+        MockWorkflow.objects.update.assert_called_once_with(42, variables=[])
+
+    # Simulate detached instance (no id attribute)
+    class DetachedWorkflow:
+        pass
+    with patch("airunner.gui.widgets.nodegraph.node_graph_widget.Workflow") as MockWorkflow:
+        MockWorkflow.objects.update = MagicMock()
+        widget._save_variables(DetachedWorkflow())
+        # Should log an error, not raise
+        assert widget.logger.error.called
+
+def test_save_connections_uses_id_and_never_accesses_orm(widget):
+    """
+    _save_connections should only use workflow.id and never access ORM attributes after session closure.
+    """
+    dummy_workflow = DummyWorkflow(id=99)
+    nodes_map = {}
+    with patch("airunner.gui.widgets.nodegraph.node_graph_widget.WorkflowConnection") as MockConn:
+        MockConn.objects.filter_by = MagicMock(return_value=[])
+        MockConn.objects.create = MagicMock()
+        MockConn.objects.delete_by = MagicMock()
+        widget.graph = MagicMock()
+        widget.graph.all_nodes.return_value = []
+        widget._save_connections(dummy_workflow, nodes_map)
+        MockConn.objects.filter_by.assert_called_once_with(workflow_id=99)
+
+    # Simulate detached instance (no id attribute)
+    class DetachedWorkflow:
+        pass
+    with patch("airunner.gui.widgets.nodegraph.node_graph_widget.WorkflowConnection") as MockConn:
+        MockConn.objects.filter_by = MagicMock(return_value=[])
+        widget._save_connections(DetachedWorkflow(), nodes_map)
+        # Should log an error, not raise
+        assert widget.logger.error.called

--- a/src/airunner/gui/widgets/nodegraph/tests/test_workflow_save_detached_instance.py
+++ b/src/airunner/gui/widgets/nodegraph/tests/test_workflow_save_detached_instance.py
@@ -1,0 +1,83 @@
+"""
+Unit tests for workflow save logic to ensure no DetachedInstanceError occurs.
+These tests are headless and do not launch the GUI.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+from airunner.gui.widgets.nodegraph.node_graph_widget import NodeGraphWidget
+
+
+class DummyVar:
+    def to_dict(self):
+        return {"foo": "bar"}
+
+
+@pytest.fixture
+def widget():
+    w = NodeGraphWidget.__new__(NodeGraphWidget)  # Do not call __init__
+    w.ui = MagicMock()
+    w.ui.variables.variables = [DummyVar()]
+    # Patch the logger property for this instance only
+    patcher = patch.object(
+        NodeGraphWidget, "logger", new_callable=PropertyMock
+    )
+    mock_logger = patcher.start()
+    w._logger_patcher = patcher  # Store to stop later
+    mock_logger.return_value = MagicMock()
+    return w
+
+
+def test_save_variables_uses_id_and_not_orm(widget):
+    """Test _save_variables only uses workflow.id and never accesses ORM attributes after session closure."""
+
+    # Simulate a detached ORM object: accessing any attribute except 'id' raises
+    class DetachedWorkflow:
+        id = 42
+
+        def __getattribute__(self, name):
+            if name == "id":
+                return 42
+            raise Exception("DetachedInstanceError: ORM object is detached")
+
+    workflow = DetachedWorkflow()
+    with patch(
+        "airunner.gui.widgets.nodegraph.node_graph_widget.Workflow"
+    ) as MockWorkflow:
+        MockWorkflow.objects.update.return_value = True
+        widget._save_variables(workflow)
+        MockWorkflow.objects.update.assert_called_once_with(
+            42, variables=[{"foo": "bar"}]
+        )
+        # No exception should be raised
+
+
+def test_save_connections_uses_id_and_not_orm(widget):
+    """Test _save_connections only uses workflow.id and never accesses ORM attributes after session closure."""
+
+    class DetachedWorkflow:
+        id = 99
+
+        def __getattribute__(self, name):
+            if name == "id":
+                return 99
+            raise Exception("DetachedInstanceError: ORM object is detached")
+
+    workflow = DetachedWorkflow()
+    widget.graph = MagicMock()
+    widget.graph.all_nodes.return_value = []
+    with patch(
+        "airunner.gui.widgets.nodegraph.node_graph_widget.WorkflowConnection"
+    ) as MockConn:
+        MockConn.objects.filter_by.return_value = []
+        widget.logger = MagicMock()
+        widget._save_connections(workflow, {})
+        MockConn.objects.filter_by.assert_called_once_with(workflow_id=99)
+        # No exception should be raised
+
+
+@pytest.fixture(autouse=True)
+def cleanup_logger_patch(widget):
+    yield
+    if hasattr(widget, "_logger_patcher"):
+        widget._logger_patcher.stop()


### PR DESCRIPTION
…t tests

- Refactor workflow saving logic in NodeGraphWidget to avoid accessing attributes of detached SQLAlchemy ORM instances; always use workflow_id for DB operations and logging.
- Ensure _save_variables and _save_connections only use workflow_id, not workflow ORM objects, after session closure.
- Remove legacy or broken GUI-dependent tests.
- Add new headless unit tests for workflow save/update logic, mocking all DB and UI dependencies, ensuring tests run in terminal without launching the application or requiring user input.
- Improve error handling and logging for workflow save operations.
- Adhere to TDD and project coding guidelines.