### PR TITLE
feat(vendor/melo): Add get_bert stub for testing

### DIFF
--- a/src/airunner/utils/text/formatter_extended.py
+++ b/src/airunner/utils/text/formatter_extended.py
@@ -263,9 +263,9 @@ class FormatterExtended:
 
     @staticmethod
     def strip_nonlinguistic(text: str) -> str:
-        """
+        r"""
         Remove LaTeX, code blocks, and inline code from the text to improve language detection.
-        - Removes LaTeX ($...$, $$...$$, \[...\], \(...\))
+        - Removes LaTeX ($...$, $$...$$, \\[...\\], \\(...\\))
         - Removes fenced code blocks (```...```)
         - Removes inline code (`...`)
         """

--- a/src/airunner/vendor/nodegraphqt/qgraphics/node_backdrop.py
+++ b/src/airunner/vendor/nodegraphqt/qgraphics/node_backdrop.py
@@ -164,6 +164,7 @@ class BackdropNodeItem(AbstractNodeItem):
     def on_sizer_pos_changed(self, pos):
         self._width = pos.x() + self._sizer.size
         self._height = pos.y() + self._sizer.size
+        self.update(self.boundingRect())  # Ensure visual update during resize
 
     def on_sizer_pos_mouse_release(self):
         size = {


### PR DESCRIPTION
Add a stub implementation of get_bert in vendor/melo/text/__init__.py to satisfy imports in data_utils.py during testing. This prevents import errors when the actual get_bert implementation is unavailable.

docs: Clarify LaTeX delimiters in strip_nonlinguistic docstring

Update the docstring for strip_nonlinguistic to use a raw string and clarify that LaTeX delimiters are double-backslashed for clarity in documentation. No functional code changes.

fix(node_backdrop): Ensure visual update during backdrop resize

Call self.update(self.boundingRect()) in on_sizer_pos_changed to force a visual update when resizing a backdrop node. This improves the user experience by making the resize operation visually responsive.