### PR TITLE
Make download/progress signals object-typed to avoid OverflowError on…

### DIFF
--- a/src/airunner/components/application/workers/civit_ai_download_worker.py
+++ b/src/airunner/components/application/workers/civit_ai_download_worker.py
@@ -12,7 +12,9 @@ class CivitAIDownloadWorker(MediatorMixin, QObject):
     Worker class for downloading files from CivitAI with progress tracking and cancellation support.
     """
 
-    progress = Signal(int, int)  # current, total
+    # Use object-typed signals for progress so very large byte counts do
+    # not raise OverflowError when converted to C integers by PySide.
+    progress = Signal(object, object)  # current, total
     finished = Signal()
     failed = Signal(Exception)
 

--- a/src/airunner/components/application/workers/download_worker.py
+++ b/src/airunner/components/application/workers/download_worker.py
@@ -19,7 +19,9 @@ class DownloadWorker(Worker):
         failed(Exception): Emitted on error.
     """
 
-    progress = Signal(int, int)  # current, total (legacy)
+    # Use object-typed signal to avoid OverflowError when emitting very
+    # large byte counts. Receivers should accept Python ints (unbounded).
+    progress = Signal(object, object)  # current, total (legacy)
     finished = Signal(dict)
     failed = Signal(Exception)
     running = False

--- a/src/airunner/components/application/workers/qt_civitai_workers.py
+++ b/src/airunner/components/application/workers/qt_civitai_workers.py
@@ -85,7 +85,11 @@ class FileDownloadWorker(QObject):
         canceled(): emitted when user canceled and worker stopped
     """
 
-    progress = Signal(int, int)
+    # Use object for the signal payload so very large byte counts (>
+    # 32-bit) don't raise OverflowError when PySide converts Python ints to
+    # C 'int'. Emitting Python objects avoids the C conversion and lets the
+    # receiver handle large integers safely.
+    progress = Signal(object, object)
     finished = Signal(str)
     error = Signal(str)
     canceled = Signal()

--- a/src/airunner/components/documents/gui/widgets/documents.py
+++ b/src/airunner/components/documents/gui/widgets/documents.py
@@ -569,7 +569,8 @@ class DocumentsWidget(
 
         class DownloadWorker(QObject):
             finished = Signal(bool, object)
-            progress = Signal(int)
+            # Use object type for consistency across download progress signals.
+            progress = Signal(object)
 
             def __init__(self, url, save_path):
                 super().__init__()

--- a/src/airunner/components/downloader/gui/windows/download_wizard/download_thread.py
+++ b/src/airunner/components/downloader/gui/windows/download_wizard/download_thread.py
@@ -3,7 +3,8 @@ from airunner.utils.network.huggingface_downloader import HuggingfaceDownloader
 
 
 class DownloadThread(QThread):
-    progress_updated = Signal(int, int)
+    # Use object-typed signal to avoid OverflowError for very large values
+    progress_updated = Signal(object, object)
     download_finished = Signal()
     file_download_finished = Signal()
 

--- a/src/airunner/components/downloader/gui/windows/setup_wizard/installation_settings/install_page.py
+++ b/src/airunner/components/downloader/gui/windows/setup_wizard/installation_settings/install_page.py
@@ -112,7 +112,9 @@ class InstallWorker(
     QObject,
 ):
     file_download_finished = Signal()
-    progress_updated = Signal(int, int)
+    # Use object-typed signal to avoid potential overflow when emitting large
+    # byte counts. Values emitted will typically be Python ints.
+    progress_updated = Signal(object, object)
 
     def __init__(self, parent, models_enabled: List[str], initialize_gui=True):
         super().__init__()

--- a/src/airunner/utils/application/background_worker.py
+++ b/src/airunner/utils/application/background_worker.py
@@ -13,7 +13,9 @@ class BackgroundWorker(QThread):
 
     # Define signals
     taskFinished = Signal(dict)
-    progressUpdate = Signal(int)
+    # Use object-typed signal to avoid OverflowError for very large values and
+    # keep consistency across progress signals in the project.
+    progressUpdate = Signal(object)
     statusUpdate = Signal(str)
 
     def __init__(


### PR DESCRIPTION
… large byte counts

Change various Signal(int/Signal(int,int)) declarations used for download progress to Signal(object, ...) so PySide doesn't attempt C int conversion on large Python ints. This prevents repeated OverflowError during large downloads.

Files: qt_civitai_workers.py, civit_ai_download_worker.py, download_worker.py, download_thread.py, install_page.py, documents.py, background_worker.py