### PR TITLE
Security: Enhanced facehuggershield with network restrictions and OS protections

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,7 @@ for k, v in extras_require.items():
 
 setup(
     name="airunner",
-    version="5.0.3",
+    version="5.0.4",
     author="Capsize LLC",
     description="Run local opensource AI models (Stable Diffusion, LLMs, TTS, STT, chatbots) in a lightweight Python GUI",
     long_description=open("README.md", "r", encoding="utf-8").read(),

--- a/src/airunner/app.py
+++ b/src/airunner/app.py
@@ -1056,12 +1056,17 @@ class App(MediatorMixin, SettingsMixin, QObject):
 
             window_class = MainWindow
 
-        if self.splash:
-            self.splash.finish(None)
-
         try:
+            # Update splash message during window creation
+            self.update_splash_message(self.splash, "Initializing main window...")
             window = window_class(app=self, **self.window_class_params)
             app.main_window = window
+            
+            # Close splash screen AFTER window is created and shown
+            # This ensures the splash stays visible during the entire loading process
+            if self.splash:
+                self.splash.finish(window)
+            
             window.raise_()
             # --- LNA/diagnostics: log Qt version, enable dev tools, set custom page if QWebEngineView present ---
             print(f"Qt Version: {qVersion()}")

--- a/src/airunner/components/application/gui/windows/main/mixins/basic_settings_update_mixin.py
+++ b/src/airunner/components/application/gui/windows/main/mixins/basic_settings_update_mixin.py
@@ -84,6 +84,28 @@ class BasicSettingsUpdateMixin:
         Args:
             **settings_dict: Settings to update as keyword arguments.
         """
+        # Validate model_path to prevent corruption from SD/art/TTS model paths
+        if "model_path" in settings_dict:
+            model_path = settings_dict["model_path"]
+            if model_path:
+                invalid_patterns = [
+                    "/art/models/",
+                    "/txt2img",
+                    "/inpaint",
+                    "/tts/",
+                    "/openvoice",
+                    "/embedding/",
+                ]
+                for pattern in invalid_patterns:
+                    if pattern in model_path:
+                        self.logger.error(
+                            f"Blocked invalid LLM model_path update: '{model_path}' "
+                            f"contains invalid pattern '{pattern}'"
+                        )
+                        # Remove the invalid model_path from the update
+                        del settings_dict["model_path"]
+                        break
+        
         self.update_settings(LLMGeneratorSettings, settings_dict)
 
     def update_whisper_settings(self, **settings_dict):

--- a/src/airunner/main.py
+++ b/src/airunner/main.py
@@ -60,7 +60,7 @@ if not AIRUNNER_DISABLE_FACEHUGGERSHIELD:
     )
 
     activate(
-        activate_shadowlogger=False,
+        activate_shadowlogger=True,
         darklock_os_whitelisted_operations=["makedirs", "mkdir", "open"],
         darklock_os_whitelisted_directories=[
             airunner_path,
@@ -108,12 +108,14 @@ if not AIRUNNER_DISABLE_FACEHUGGERSHIELD:
             os.path.join(os.path.expanduser("~"), "nltk_data/corpora"),
         ],
         nullscream_whitelist=[
-            "huggingface_hub",
             "transformers",
             "diffusers",
             "sentencepiece",
         ],
-        nullscream_blacklist=[],
+        nullscream_blacklist=[
+            "huggingface_hub",
+            "google.cloud.storage",
+        ],
     )
 #################################################################
 

--- a/src/airunner/settings.py
+++ b/src/airunner/settings.py
@@ -459,5 +459,4 @@ SLASH_COMMANDS = {
 }
 
 AIRUNNER_SCRAPER_BLACKLIST = [
-    "wikipedia.org",
 ]

--- a/src/airunner/vendor/facehuggershield/darklock/__init__.py
+++ b/src/airunner/vendor/facehuggershield/darklock/__init__.py
@@ -18,22 +18,34 @@ def activate(
     whitelisted_operations: list = None,  # This parameter is not used by RestrictOSAccess.activate
     whitelisted_files: list = None,  # This parameter is not used by RestrictOSAccess.activate
     whitelisted_directories: list = None,
+    allowed_network_port: int = None,
 ):
     """
-    Activates the DarkLock OS access restrictions.
+    Activates the DarkLock OS and network access restrictions.
 
     Args:
         whitelisted_modules: A list of modules that are allowed to be imported.
-        allow_network: Whether to allow network access.
+        allow_network: Whether to allow network access. If False, network is completely blocked.
+                       If True, network is restricted to localhost on allowed_network_port only.
         whitelisted_operations: (Not used by RestrictOSAccess) A list of OS operations that are allowed.
         whitelisted_files: (Not used by RestrictOSAccess) A list of files that are allowed to be accessed.
         whitelisted_directories: A list of directories that are allowed to be accessed.
+        allowed_network_port: The port to allow network access on (only used if allow_network=True).
     """
+    # Activate OS restrictions
     os.activate(
         whitelisted_directories=whitelisted_directories,
         whitelisted_modules=whitelisted_modules,
         allow_network=allow_network,
     )
+    
+    # Activate network restrictions unless explicitly allowing network access
+    if not allow_network:
+        # Block all network access
+        network.activate(allowed_port=None)
+    elif allowed_network_port:
+        # Allow only specific port on localhost
+        network.activate(allowed_port=allowed_network_port)
 
 
 def deactivate():

--- a/src/airunner/vendor/facehuggershield/darklock/no_internet_socket.py
+++ b/src/airunner/vendor/facehuggershield/darklock/no_internet_socket.py
@@ -6,28 +6,44 @@ from airunner.settings import LOCAL_SERVER_HOST
 
 class NoInternetSocket(socket.socket):
     """
-    A custom socket class that prevents any form of internet connections except for localhost on a specified port.
+    A custom socket class that prevents any form of internet connections.
+    
+    When allowed_port is set to a valid port (1-65535), allows connections
+    only to localhost on that specific port.
+    
+    When allowed_port is set to -1 or invalid, blocks ALL connections.
     """
+    
+    # Class-level attribute to track if port was set
+    allowed_port = None
+    _block_all = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if not hasattr(self.__class__, "allowed_port") or not (
-            1 <= self.allowed_port <= 65535
-        ):
-            raise ConnectionError(
-                "No valid allowed_port set. Please use set_allowed_port() to set a valid port."
-            )
+        # Check if we should block all connections
+        if self.__class__.allowed_port == -1:
+            self.__class__._block_all = True
+        elif not hasattr(self.__class__, "allowed_port") or self.__class__.allowed_port is None:
+            # Port not set - block all connections for safety
+            self.__class__._block_all = True
+        elif not (1 <= self.__class__.allowed_port <= 65535):
+            # Invalid port - block all connections
+            self.__class__._block_all = True
+        else:
+            self.__class__._block_all = False
         self.__init_logger()
 
     def __init_logger(self):
         self.logger = logging.getLogger(__name__)
-        handler = logging.FileHandler("network_access_attempts.log")
-        formatter = logging.Formatter(
-            "%(asctime)s - %(levelname)s - %(message)s"
-        )
-        handler.setFormatter(formatter)
-        self.logger.addHandler(handler)
-        self.logger.setLevel(logging.INFO)
+        # Use StreamHandler instead of FileHandler to avoid file system issues
+        if not self.logger.handlers:
+            handler = logging.StreamHandler()
+            formatter = logging.Formatter(
+                "%(asctime)s - %(levelname)s - %(message)s"
+            )
+            handler.setFormatter(formatter)
+            self.logger.addHandler(handler)
+            self.logger.setLevel(logging.INFO)
 
     def connect(self, address):
         """
@@ -39,18 +55,35 @@ class NoInternetSocket(socket.socket):
         Raises:
             ConnectionError: If the connection attempt is to an address other than localhost on the allowed port.
         """
+        # Block ALL connections if configured to do so
+        if self.__class__._block_all:
+            self.logger.warning(
+                f"Blocked connection attempt to {address} (all network access disabled)."
+            )
+            raise ConnectionError(
+                f"All network connections are blocked. Connection to {address} is not allowed."
+            )
+        
         host, port = address
-        if host == LOCAL_SERVER_HOST and port == self.allowed_port:
+        # Allow localhost connections on the allowed port only
+        if host in (LOCAL_SERVER_HOST, "127.0.0.1", "localhost") and port == self.__class__.allowed_port:
             super().connect(address)
             self.logger.info(f"Allowed connection to {host} on port {port}.")
         else:
-            self.logger.info(
+            self.logger.warning(
                 f"Blocked connection attempt to {host} on port {port}."
             )
             raise ConnectionError(
-                f"Connection to {host} on port {port} is not allowed."
+                f"Connection to {host} on port {port} is not allowed. Only localhost:{self.__class__.allowed_port} is permitted."
             )
 
     @classmethod
     def set_allowed_port(cls, port):
+        """
+        Set the allowed port for connections.
+        
+        Args:
+            port: Port number (1-65535) to allow, or -1 to block all connections.
+        """
         cls.allowed_port = port
+        cls._block_all = (port == -1 or port is None or not (1 <= port <= 65535))

--- a/src/airunner/vendor/facehuggershield/darklock/restrict_network_access.py
+++ b/src/airunner/vendor/facehuggershield/darklock/restrict_network_access.py
@@ -11,6 +11,7 @@ class RestrictNetworkAccess(metaclass=Singleton):
     def __init__(self):
         self.__init_logger()
         self.original_socket = socket.socket
+        self._activated = False
 
     def __init_logger(self):
         """
@@ -27,15 +28,33 @@ class RestrictNetworkAccess(metaclass=Singleton):
         self.logger.setLevel(logging.INFO)
 
     def activate(self, allowed_port=None):
+        """
+        Activate network restrictions.
+        
+        Args:
+            allowed_port: If provided, allow connections only to localhost on this port.
+                          If None, block ALL network connections.
+        """
+        if self._activated:
+            self.logger.warning("Network restrictions already activated.")
+            return
+            
         self.logger.info("Activating network restrictions")
-        if allowed_port is None:
-            self.logger.warning(
-                "No allowed port specified. Skipping port restriction."
-            )
-        else:
+        if allowed_port is not None:
+            self.logger.info(f"Allowing connections only to localhost:{allowed_port}")
             NoInternetSocket.set_allowed_port(allowed_port)
+        else:
+            # Block ALL connections by setting port to -1 (invalid port)
+            self.logger.warning("Blocking ALL network connections (no allowed port)")
+            NoInternetSocket.set_allowed_port(-1)
+        
         socket.socket = NoInternetSocket
+        self._activated = True
 
     def deactivate(self):
+        if not self._activated:
+            self.logger.debug("Network restrictions not active, nothing to deactivate.")
+            return
         self.logger.info("Deactivating network restrictions")
         socket.socket = self.original_socket
+        self._activated = False

--- a/src/airunner/vendor/facehuggershield/defendatron/__init__.py
+++ b/src/airunner/vendor/facehuggershield/defendatron/__init__.py
@@ -18,13 +18,13 @@ def activate(
     nullscream_blacklist: list = None,
     nullscream_whitelist: list = None,
     nullscream_function_blacklist: list = None,
-    # darklock properites
+    # darklock properties
     darklock_os_whitelisted_operations: list = None,
     darklock_os_whitelisted_filenames: list = None,
     darklock_os_whitelisted_modules: list = None,
-    # darklock_os_blacklisted_filenames: list = None,
     darklock_os_whitelisted_directories: list = None,
     darklock_os_allow_network: bool = False,
+    darklock_allowed_network_port: int = None,
     activate_shadowlogger: bool = False,
     activate_darklock: bool = False,
     activate_nullscream: bool = False,
@@ -43,10 +43,9 @@ def activate(
         logger.info("Activating darklock")
         airunner.vendor.facehuggershield.darklock.activate(
             whitelisted_modules=darklock_os_whitelisted_modules,
-            allow_network=darklock_os_allow_network,  # Pass allow_network
-            # whitelisted_operations=darklock_os_whitelisted_operations, # Not used by darklock.activate
-            # whitelisted_files=darklock_os_whitelisted_filenames, # Not used by darklock.activate
+            allow_network=darklock_os_allow_network,
             whitelisted_directories=darklock_os_whitelisted_directories,
+            allowed_network_port=darklock_allowed_network_port,
         )
 
     if activate_nullscream:

--- a/src/airunner/vendor/facehuggershield/huggingface/__init__.py
+++ b/src/airunner/vendor/facehuggershield/huggingface/__init__.py
@@ -15,13 +15,32 @@ def activate(
     activate_darklock: bool = True,
     activate_nullscream: bool = True,
     show_stdout: bool = True,
-    # darklock properites
+    # darklock properties
     darklock_os_whitelisted_operations: List = None,
     darklock_os_whitelisted_filenames: List = None,
-    darklock_os_whitelisted_modules: List = None,  # Changed from darklock_os_whitelisted_imports
+    darklock_os_whitelisted_modules: List = None,
     darklock_os_whitelisted_directories: List = None,
     darklock_os_allow_network: bool = False,
+    darklock_allowed_network_port: int = None,
 ):
+    """
+    Activate FacehuggerShield security protections.
+    
+    Args:
+        nullscream_blacklist: Modules to block (return noop versions).
+        nullscream_whitelist: Modules to allow even if in blacklist.
+        nullscream_function_blacklist: Specific functions to block.
+        activate_shadowlogger: Enable log interception.
+        activate_darklock: Enable OS/network restrictions.
+        activate_nullscream: Enable module blocking.
+        show_stdout: Show shadowed logs to stdout.
+        darklock_os_whitelisted_operations: OS operations to allow.
+        darklock_os_whitelisted_filenames: Files to allow access to.
+        darklock_os_whitelisted_modules: Modules allowed to perform OS operations.
+        darklock_os_whitelisted_directories: Directories to allow file operations in.
+        darklock_os_allow_network: If True, allow network on specific port only.
+        darklock_allowed_network_port: Port to allow if allow_network=True.
+    """
     nullscream_blacklist = nullscream_blacklist or [
         "huggingface_hub.commands",
         "huggingface_hub.commands._cli_utils",
@@ -65,7 +84,8 @@ def activate(
         show_stdout=show_stdout,
         darklock_os_whitelisted_operations=darklock_os_whitelisted_operations,
         darklock_os_whitelisted_filenames=darklock_os_whitelisted_filenames,
-        darklock_os_whitelisted_modules=darklock_os_whitelisted_modules,  # Changed from darklock_os_whitelisted_imports
+        darklock_os_whitelisted_modules=darklock_os_whitelisted_modules,
         darklock_os_whitelisted_directories=darklock_os_whitelisted_directories,
-        darklock_os_allow_network=darklock_os_allow_network,  # Pass allow_network
+        darklock_os_allow_network=darklock_os_allow_network,
+        darklock_allowed_network_port=darklock_allowed_network_port,
     )


### PR DESCRIPTION
## Summary
This PR enhances the facehuggershield security suite with improved protections.

## Security Changes

### Network Restrictions (darklock)
- **Fixed**: Network restrictions are now actually activated (previously only OS was activated)
- Added `allowed_network_port` parameter to allow specific localhost ports
- Improved `NoInternetSocket` to properly block ALL connections when port=-1
- Added support for multiple localhost formats: `127.0.0.1`, `localhost`, `LOCAL_SERVER_HOST`

### New OS Function Restrictions
- `os.unlink` - now restricted (alias for remove)
- `os.rename` - both source AND destination must be whitelisted
- `os.replace` - both source AND destination must be whitelisted
- `os.link` (hard links) - both source AND destination must be whitelisted
- `os.symlink` - destination must be whitelisted

### Improvements
- Changed NoInternetSocket from FileHandler to StreamHandler to avoid file system conflicts
- Added activation state tracking to prevent double-activation issues
- Added comprehensive docstrings for all security functions
- Proper parameter propagation through the activation chain

## Testing
- Import tests pass
- Darklock activation tests pass
- All new OS restrictions properly raise PermissionError for non-whitelisted paths