### PR TITLE
refactor: split large panel files into sub-components

### DIFF
--- a/airunner_web_client/src/components/panels/ArtModelPanel.tsx
+++ b/airunner_web_client/src/components/panels/ArtModelPanel.tsx
@@ -5,34 +5,17 @@ import {
 } from "../../api/client";
 import type { ArtOptionsResponse } from "../../api/client";
 import { BASE_URL } from "../../types/api";
-import Form from "react-bootstrap/Form";
-import ProgressBar from "react-bootstrap/ProgressBar";
-import SliderWithSpinbox from "./SliderWithSpinbox";
 import VersionSelector from "./art-model/VersionSelector";
 import ModelSelector from "./art-model/ModelSelector";
 import SchedulerSelector from "./art-model/SchedulerSelector";
 import PrecisionSelector from "./art-model/PrecisionSelector";
 import SeedControls from "./art-model/SeedControls";
-
-const LS_KEY = "airunner_art_settings";
-
-function saveToStorage(key: string, val: number) {
-  try {
-    const data = JSON.parse(localStorage.getItem(LS_KEY) || "{}");
-    data[key] = val;
-    localStorage.setItem(LS_KEY, JSON.stringify(data));
-  } catch { /* */ }
-}
-
-function loadFromStorage(key: string, fallback: number): number {
-  try {
-    const data = JSON.parse(localStorage.getItem(LS_KEY) || "{}");
-    const v = data[key];
-    return v !== undefined ? Number(v) : fallback;
-  } catch {
-    return fallback;
-  }
-}
+import VRAMEstimate from "./art-model/VRAMEstimate";
+import ArtModelSliders from "./art-model/ArtModelSliders";
+import {
+  saveToStorage,
+  loadFromStorage,
+} from "./art-model/ArtModelStorage";
 
 export default function ArtModelPanel() {
   const [version, setVersion] = useState("");
@@ -247,76 +230,47 @@ export default function ArtModelPanel() {
         }}
       />
 
-      {vramEstimate !== null && (
-        <div className="mt-2 mb-2">
-          <small style={{ color: "var(--theme-text-secondary)" }}>
-            Estimated VRAM: {vramEstimate.toFixed(1)} GB
-          </small>
-          <ProgressBar
-            now={Math.min((vramEstimate / 24) * 100, 100)}
-            variant={vramEstimate > 20 ? "danger" : "success"}
-            className="mt-1"
-            style={{ height: 6 }}
-          />
-        </div>
-      )}
+      <VRAMEstimate vramGb={vramEstimate} />
 
       <hr className="border-secondary" />
 
-      <SliderWithSpinbox
-        label="Samples"
-        value={nSamples}
-        min={1}
-        max={1000}
-        step={1}
-        defaultValue={1}
-        onChange={(v) => { setNSamples(v); saveToStorage("n_samples", v); persist({ n_samples: v }); }}
-      />
-      <SliderWithSpinbox
-        label="Batch"
-        value={imagesPerBatch}
-        min={1}
-        max={6}
-        step={1}
-        defaultValue={1}
-        onChange={(v) => { setImagesPerBatch(v); saveToStorage("images_per_batch", v); persist({ images_per_batch: v }); }}
-      />
-      <SliderWithSpinbox
-        label="Steps"
-        value={steps}
-        min={1}
-        max={150}
-        step={1}
-        defaultValue={20}
-        onChange={(v) => { setSteps(v); saveToStorage("steps", v); persist({ steps: v }); }}
-      />
-      <SliderWithSpinbox
-        label="CFG"
-        value={cfgScale}
-        min={1}
-        max={30}
-        step={0.5}
-        displayAsFloat
-        defaultValue={7.5}
-        onChange={(v) => { setCfgScale(v); saveToStorage("cfg_scale", v); persist({ cfg_scale: v }); }}
-      />
-      <SliderWithSpinbox
-        label="Width"
-        value={width}
-        min={64}
-        max={4096}
-        step={64}
-        defaultValue={1024}
-        onChange={(v) => { setWidth(v); saveToStorage("width", v); persist({ width: v }); }}
-      />
-      <SliderWithSpinbox
-        label="Height"
-        value={height}
-        min={64}
-        max={4096}
-        step={64}
-        defaultValue={1024}
-        onChange={(v) => { setHeight(v); saveToStorage("height", v); persist({ height: v }); }}
+      <ArtModelSliders
+        nSamples={nSamples}
+        imagesPerBatch={imagesPerBatch}
+        steps={steps}
+        cfgScale={cfgScale}
+        width={width}
+        height={height}
+        onNSamplesChange={(v) => {
+          setNSamples(v);
+          saveToStorage("n_samples", v);
+          persist({ n_samples: v });
+        }}
+        onImagesPerBatchChange={(v) => {
+          setImagesPerBatch(v);
+          saveToStorage("images_per_batch", v);
+          persist({ images_per_batch: v });
+        }}
+        onStepsChange={(v) => {
+          setSteps(v);
+          saveToStorage("steps", v);
+          persist({ steps: v });
+        }}
+        onCfgScaleChange={(v) => {
+          setCfgScale(v);
+          saveToStorage("cfg_scale", v);
+          persist({ cfg_scale: v });
+        }}
+        onWidthChange={(v) => {
+          setWidth(v);
+          saveToStorage("width", v);
+          persist({ width: v });
+        }}
+        onHeightChange={(v) => {
+          setHeight(v);
+          saveToStorage("height", v);
+          persist({ height: v });
+        }}
       />
 
       <SeedControls

--- a/airunner_web_client/src/components/panels/ArtPromptPanel.tsx
+++ b/airunner_web_client/src/components/panels/ArtPromptPanel.tsx
@@ -1,42 +1,12 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import {
-  startArtGeneration,
-  getArtJobStatus,
-} from "../../api/client";
-import ProgressBar from "react-bootstrap/ProgressBar";
+import { useState, useEffect, useCallback } from "react";
 import PromptInput from "./art-prompt/PromptInput";
 import { EmbeddingPills, LoraPills } from "./art-prompt/ActivePills";
 import ArtPromptFooter from "./art-prompt/ArtPromptFooter";
-
-const STORAGE_KEY = "airunner_art_prompt_data";
-
-interface PromptData {
-  prompt: string;
-  negative_prompt: string;
-  secondary_prompt: string;
-  secondary_negative_prompt: string;
-}
-
-const DEFAULT_PROMPT_DATA: PromptData = {
-  prompt: "",
-  negative_prompt: "",
-  secondary_prompt: "",
-  secondary_negative_prompt: "",
-};
-
-function loadPromptData(): PromptData {
-  try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (raw) return JSON.parse(raw) as PromptData;
-  } catch { /* ignore */ }
-  return { ...DEFAULT_PROMPT_DATA };
-}
-
-function savePromptData(data: Record<string, string>) {
-  try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
-  } catch { /* ignore */ }
-}
+import { useArtGeneration } from "./art-prompt/useArtGeneration";
+import {
+  loadPromptData,
+  savePromptData,
+} from "./art-prompt/ArtPromptStorage";
 
 export default function ArtPromptPanel() {
   const initial = loadPromptData();
@@ -55,10 +25,6 @@ export default function ArtPromptPanel() {
   const [secondaryNegativePrompt, setSecondaryNegativePrompt] = useState(
     initial.secondary_negative_prompt,
   );
-  const [generating, setGenerating] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const jobIdRef = useRef<string | null>(null);
-  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const [artVersion, setArtVersion] = useState(savedVersion);
   const [artModel, setArtModel] = useState(() => {
     try { return localStorage.getItem("airunner_art_model") || ""; }
@@ -73,6 +39,13 @@ export default function ArtPromptPanel() {
   const [activeEmbeddings, setActiveEmbeddings] = useState<
     { id: number; name: string }[]
   >([]);
+
+  const {
+    generating,
+    progress,
+    handleSubmit,
+    handleCancel,
+  } = useArtGeneration();
 
   const reloadActiveLoras = useCallback(async () => {
     try {
@@ -133,7 +106,6 @@ export default function ArtPromptPanel() {
     return () => {
       window.removeEventListener("art-version-changed", versionHandler);
       window.removeEventListener("art-model-changed", modelHandler);
-      if (pollRef.current) clearInterval(pollRef.current);
     };
   }, [reloadActiveLoras, reloadActiveEmbeddings]);
 
@@ -156,51 +128,18 @@ export default function ArtPromptPanel() {
     savePromptData({ ...current, ...updates });
   };
 
-  const handleSubmit = async () => {
-    if (generating || !prompt.trim()) return;
-    setGenerating(true);
-    setProgress(0);
-    try {
-      const scheduler = (() => {
-        try { return localStorage.getItem("airunner_art_scheduler") || ""; }
-        catch { return ""; }
-      })();
-      const resp = await startArtGeneration({
-        prompt: prompt.trim(),
-        negative_prompt: negativePrompt.trim() || undefined,
-        model: artModel || undefined,
-        version: artVersion || undefined,
-        scheduler: scheduler || undefined,
-        num_images: 1,
-      });
-      jobIdRef.current = resp.job_id;
-      pollRef.current = setInterval(async () => {
-        try {
-          const status = await getArtJobStatus(resp.job_id);
-          setProgress(status.progress ?? 0);
-          if (
-            status.status === "complete" ||
-            status.status === "failed"
-          ) {
-            handleCancel();
-          }
-        } catch {
-          // keep polling
-        }
-      }, 1000);
-    } catch {
-      setGenerating(false);
-    }
-  };
-
-  const handleCancel = () => {
-    if (pollRef.current) {
-      clearInterval(pollRef.current);
-      pollRef.current = null;
-    }
-    jobIdRef.current = null;
-    setGenerating(false);
-    setProgress(0);
+  const onSubmit = () => {
+    const scheduler = (() => {
+      try { return localStorage.getItem("airunner_art_scheduler") || ""; }
+      catch { return ""; }
+    })();
+    handleSubmit({
+      prompt,
+      negativePrompt,
+      artModel,
+      artVersion,
+      scheduler,
+    });
   };
 
   const deactivateLora = (id: number) => {
@@ -301,7 +240,7 @@ export default function ArtPromptPanel() {
             setIsZImage(v === "Z-Image Turbo");
           }}
           onModelChange={(m) => setArtModel(m)}
-          onSubmit={handleSubmit}
+          onSubmit={onSubmit}
           onCancel={handleCancel}
         />
       </div>

--- a/airunner_web_client/src/components/panels/CanvasPanel.tsx
+++ b/airunner_web_client/src/components/panels/CanvasPanel.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect } from "react";
+import { useRef, useState, useCallback } from "react";
 import Konva from "konva";
 import {
   useCanvasContext,
@@ -9,33 +9,28 @@ import type { CanvasStageHandle } from "../../features/canvas/CanvasStage";
 import CanvasStage from "../../features/canvas/CanvasStage";
 import ToolBar, { type ToolbarDock } from "../../features/canvas/ToolBar";
 import CanvasSettingsModal from "../../features/canvas/CanvasSettingsModal";
-import ImageDropModal, { fitDimensions, type DropResizeMode } from "../../features/canvas/ImageDropModal";
+import ImageDropModal, {
+  type DropResizeMode,
+  fitDimensions,
+} from "../../features/canvas/ImageDropModal";
 import CanvasLayersSidebar from "../../features/canvas/CanvasLayersSidebar";
-
-interface PendingDrop {
-  base64: string;
-  x: number;
-  y: number;
-  naturalW: number;
-  naturalH: number;
-}
+import CanvasStatusBar from "./canvas/CanvasStatusBar";
+import { useCanvasImageDrop } from "./canvas/useCanvasImageDrop";
 
 export default function CanvasPanel() {
   const canvas = useCanvasContext();
 
-  const stageRef        = useRef<Konva.Stage>(null!) as React.RefObject<Konva.Stage>;
-  const gridLayerRef    = useRef<Konva.Layer>(null!) as React.RefObject<Konva.Layer>;
-  const maskLayerRef    = useRef<Konva.Layer>(null!) as React.RefObject<Konva.Layer>;
+  const stageRef = useRef<Konva.Stage>(null!) as React.RefObject<Konva.Stage>;
+  const gridLayerRef = useRef<Konva.Layer>(null!) as React.RefObject<Konva.Layer>;
+  const maskLayerRef = useRef<Konva.Layer>(null!) as React.RefObject<Konva.Layer>;
   const canvasHandleRef = useRef<CanvasStageHandle>(null);
 
-  const [showGrid,       setShowGrid]       = useState(true);
-  const [zoom,           setZoom]           = useState(1);
-  const [gridLocked,     setGridLocked]     = useState(false);
-  const [showSettings,   setShowSettings]   = useState(false);
+  const [showGrid, setShowGrid] = useState(true);
+  const [zoom, setZoom] = useState(1);
+  const [gridLocked, setGridLocked] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [showNewDocModal, setShowNewDocModal] = useState(false);
-  const [showLayers,     setShowLayers]     = useState(true);
-  const [pendingDrop,    setPendingDrop]    = useState<PendingDrop | null>(null);
-  const [showDropModal,  setShowDropModal]  = useState(false);
+  const [showLayers, setShowLayers] = useState(true);
 
   const [dock, setDock] = useState<ToolbarDock>(() =>
     (localStorage.getItem("canvas_toolbar_dock") as ToolbarDock | null) ?? "top",
@@ -68,149 +63,56 @@ export default function CanvasPanel() {
     onSaved: () => setLastSavedDigest(currentDigest),
   });
 
-  // ── Image drop helpers ────────────────────────────────────────────────────
+  // ── Image drop handling ────────────────────────────────────────────────────
 
-  const canvasDropPos = useCallback((clientX: number, clientY: number) => {
-    const stage = stageRef.current;
-    if (!stage) return { x: 0, y: 0 };
-    const rect = stage.container().getBoundingClientRect();
-    const scale = stage.scaleX();
-    return {
-      x: (clientX - rect.left - stage.x()) / scale,
-      y: (clientY - rect.top  - stage.y()) / scale,
-    };
-  }, [stageRef]);
+  const {
+    pendingDrop,
+    showDropModal,
+    setShowDropModal,
+    handleDragOver,
+    handleDrop,
+    queueDrop,
+    useCanvasPlaceImage,
+  } = useCanvasImageDrop(stageRef);
 
-  const queueDrop = useCallback((dataUrl: string, x: number, y: number) => {
-    const img = new Image();
-    img.onload = () => {
-      setPendingDrop({ base64: dataUrl, x, y, naturalW: img.naturalWidth, naturalH: img.naturalHeight });
-      setShowDropModal(true);
-    };
-    img.src = dataUrl;
-  }, []);
+  // Listen for the "canvas-place-image" event fired by ServerImageRow
+  useCanvasPlaceImage(queueDrop);
 
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = "copy";
-  }, []);
-
-  /** Magic-byte signatures for common image formats. */
-  const IMAGE_MAGIC: [number[], number][] = [
-    [[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], 8], // PNG
-    [[0xFF, 0xD8, 0xFF],                                     3], // JPEG
-    [[0x47, 0x49, 0x46, 0x38],                               4], // GIF87a / GIF89a
-    [[0x42, 0x4D],                                            2], // BMP
-  ];
-
-  /** Check whether a file is an image using MIME type (fast) or magic bytes. */
-  const isImageFile = useCallback(async (file: File): Promise<boolean> => {
-    // Fast path: browser provides MIME type.
-    if (file.type.startsWith("image/")) return true;
-
-    // Fallback: read the first 8 bytes and check magic signatures.
-    try {
-      const buf = await file.slice(0, 8).arrayBuffer();
-      const header = new Uint8Array(buf);
-      return IMAGE_MAGIC.some(([sig, len]) =>
-        sig.every((byte, i) => header[i] === byte),
+  const handleDropConfirm = useCallback(
+    (mode: DropResizeMode) => {
+      if (!pendingDrop) return;
+      const { base64, x, y, naturalW, naturalH } = pendingDrop;
+      let w = naturalW;
+      let h = naturalH;
+      if (mode === "fit-grid") {
+        const fit = fitDimensions(
+          naturalW,
+          naturalH,
+          canvas.activeGridArea.width,
+          canvas.activeGridArea.height,
+        );
+        w = fit.w;
+        h = fit.h;
+      } else if (mode === "fit-canvas") {
+        const fit = fitDimensions(
+          naturalW,
+          naturalH,
+          canvas.documentWidth,
+          canvas.documentHeight,
+        );
+        w = fit.w;
+        h = fit.h;
+      }
+      canvas.placeImageOnNewLayer(
+        base64,
+        Math.max(0, x - w / 2),
+        Math.max(0, y - h / 2),
+        w,
+        h,
       );
-    } catch {
-      return false;
-    }
-  }, []);
-
-  const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    // Capture canvas coords synchronously before any async work
-    const { x, y } = canvasDropPos(e.clientX, e.clientY);
-
-    // Case 1: file dragged from filesystem
-    const file = e.dataTransfer.files[0];
-    if (file) {
-      isImageFile(file).then((isImage) => {
-        // Not an image by MIME or magic — ignore silently.
-        if (!isImage) {
-          // Still check for URL drop below.
-          const imageUrl = e.dataTransfer.getData("text/image-url");
-          if (imageUrl) {
-            fetch(imageUrl)
-              .then((r) => r.blob())
-              .then((blob) => {
-                const r2 = new FileReader();
-                r2.onload = (ev) => {
-                  const dataUrl = ev.target?.result as string;
-                  if (dataUrl) queueDrop(dataUrl, x, y);
-                };
-                r2.readAsDataURL(blob);
-              })
-              .catch(() => { /* silently ignore */ });
-          }
-          return;
-        }
-        const reader = new FileReader();
-        reader.onload = (ev) => {
-          const dataUrl = ev.target?.result as string;
-          if (dataUrl) queueDrop(dataUrl, x, y);
-        };
-        reader.readAsDataURL(file);
-      });
-      return;
-    }
-
-    // Case 2: URL dragged from image browser panel (no file in drop)
-    const imageUrl = e.dataTransfer.getData("text/image-url");
-    if (imageUrl) {
-      fetch(imageUrl)
-        .then((r) => r.blob())
-        .then((blob) => {
-          const reader = new FileReader();
-          reader.onload = (ev) => {
-            const dataUrl = ev.target?.result as string;
-            if (dataUrl) queueDrop(dataUrl, x, y);
-          };
-          reader.readAsDataURL(blob);
-        })
-        .catch(() => { /* silently ignore */ });
-    }
-  }, [canvasDropPos, queueDrop, isImageFile]);
-
-  // Listen for the "canvas-place-image" event fired by ServerImageRow's button
-  useEffect(() => {
-    const handler = (e: Event) => {
-      const { imageUrl } = (e as CustomEvent<{ imageUrl: string }>).detail;
-      if (!imageUrl) return;
-      fetch(imageUrl)
-        .then((r) => r.blob())
-        .then((blob) => {
-          const reader = new FileReader();
-          reader.onload = (ev) => {
-            const dataUrl = ev.target?.result as string;
-            if (dataUrl) queueDrop(dataUrl, 0, 0);
-          };
-          reader.readAsDataURL(blob);
-        })
-        .catch(() => { /* silently ignore */ });
-    };
-    window.addEventListener("canvas-place-image", handler);
-    return () => window.removeEventListener("canvas-place-image", handler);
-  }, [queueDrop]);
-
-  const handleDropConfirm = useCallback((mode: DropResizeMode) => {
-    if (!pendingDrop) return;
-    const { base64, x, y, naturalW, naturalH } = pendingDrop;
-    let w = naturalW;
-    let h = naturalH;
-    if (mode === "fit-grid") {
-      const fit = fitDimensions(naturalW, naturalH, canvas.activeGridArea.width, canvas.activeGridArea.height);
-      w = fit.w; h = fit.h;
-    } else if (mode === "fit-canvas") {
-      const fit = fitDimensions(naturalW, naturalH, canvas.documentWidth, canvas.documentHeight);
-      w = fit.w; h = fit.h;
-    }
-    canvas.placeImageOnNewLayer(base64, Math.max(0, x - w / 2), Math.max(0, y - h / 2), w, h);
-    setPendingDrop(null);
-  }, [pendingDrop, canvas]);
+    },
+    [pendingDrop, canvas],
+  );
 
   // ── New document ──────────────────────────────────────────────────────────
 
@@ -218,73 +120,84 @@ export default function CanvasPanel() {
     setShowNewDocModal(true);
   }, []);
 
-  const handleNewDocumentConfirm = useCallback((w: number, h: number, bg: string) => {
-    canvas.resetDocument();
-    canvas.setDocumentSize(w, h);
-    canvas.setDocumentBgColor(bg);
-  }, [canvas]);
+  const handleNewDocumentConfirm = useCallback(
+    (w: number, h: number, bg: string) => {
+      canvas.resetDocument();
+      canvas.setDocumentSize(w, h);
+      canvas.setDocumentBgColor(bg);
+    },
+    [canvas],
+  );
 
   // ── Canvas settings ───────────────────────────────────────────────────────
 
-  const handleApplySettings = useCallback((w: number, h: number, bg: string) => {
-    canvas.setDocumentSize(w, h);
-    canvas.setDocumentBgColor(bg);
-  }, [canvas]);
+  const handleApplySettings = useCallback(
+    (w: number, h: number, bg: string) => {
+      canvas.setDocumentSize(w, h);
+      canvas.setDocumentBgColor(bg);
+    },
+    [canvas],
+  );
 
   if (!isLoaded) {
     return (
       <div className="canvas-panel d-flex align-items-center justify-content-center h-100">
-        <div className="spinner-border spinner-border-sm" role="status" style={{ color: "var(--theme-text-secondary)" }} />
+        <div
+          className="spinner-border spinner-border-sm"
+          role="status"
+          style={{ color: "var(--theme-text-secondary)" }}
+        />
       </div>
     );
   }
+
+  const sharedToolbarProps = {
+    activeTool: canvas.activeTool,
+    brushSize: canvas.brushSize,
+    brushColor: canvas.brushColor,
+    showGrid,
+    snapToGrid: canvas.snapToGrid,
+    zoom,
+    activeGridArea: canvas.activeGridArea,
+    gridLocked,
+    onSetActiveTool: canvas.setActiveTool,
+    onSetBrushSize: canvas.setBrushSize,
+    onSetBrushColor: canvas.setBrushColor,
+    onToggleGrid: () => setShowGrid((v) => !v),
+    onToggleSnap: () => canvas.setSnapToGrid(!canvas.snapToGrid),
+    onZoomIn: () => canvasHandleRef.current?.zoomIn(),
+    onZoomOut: () => canvasHandleRef.current?.zoomOut(),
+    onZoomReset: () => canvasHandleRef.current?.zoomReset(),
+    onCenterView: () => canvasHandleRef.current?.centerView(),
+    onSetGridArea: canvas.setActiveGridArea,
+    onToggleGridLock: () => setGridLocked((v) => !v),
+    onOpenSettings: () => setShowSettings(true),
+    onSetDock: handleSetDock,
+    onUndo: canvas.undo,
+    onRedo: canvas.redo,
+    onNewDocument: handleNewDocument,
+    onClearMask: canvas.clearMask,
+    hasMaskStrokes: canvas.maskStrokes.length > 0,
+    showLayers,
+    onToggleLayers: () => setShowLayers((v) => !v),
+  };
 
   return (
     <div
       className="canvas-panel d-flex h-100 overflow-hidden flex-column"
       style={{ background: "#0a0a0f" }}
     >
-      {dock === "top" && (
-        <ToolBar
-          activeTool={canvas.activeTool}
-          brushSize={canvas.brushSize}
-          brushColor={canvas.brushColor}
-          showGrid={showGrid}
-          snapToGrid={canvas.snapToGrid}
-          zoom={zoom}
-          activeGridArea={canvas.activeGridArea}
-          gridLocked={gridLocked}
-          dock={dock}
-          onSetActiveTool={canvas.setActiveTool}
-          onSetBrushSize={canvas.setBrushSize}
-          onSetBrushColor={canvas.setBrushColor}
-          onToggleGrid={() => setShowGrid((v) => !v)}
-          onToggleSnap={() => canvas.setSnapToGrid(!canvas.snapToGrid)}
-          onZoomIn={() => canvasHandleRef.current?.zoomIn()}
-          onZoomOut={() => canvasHandleRef.current?.zoomOut()}
-          onZoomReset={() => canvasHandleRef.current?.zoomReset()}
-          onCenterView={() => canvasHandleRef.current?.centerView()}
-          onSetGridArea={canvas.setActiveGridArea}
-          onToggleGridLock={() => setGridLocked((v) => !v)}
-          onOpenSettings={() => setShowSettings(true)}
-          onSetDock={handleSetDock}
-          onUndo={canvas.undo}
-          onRedo={canvas.redo}
-          onNewDocument={handleNewDocument}
-          onClearMask={canvas.clearMask}
-          hasMaskStrokes={canvas.maskStrokes.length > 0}
-          showLayers={showLayers}
-          onToggleLayers={() => setShowLayers((v) => !v)}
-        />
-      )}
+      {dock === "top" && <ToolBar {...sharedToolbarProps} dock="top" />}
 
       {/* Canvas viewport + layers sidebar */}
       <div
         className="flex-grow-1 d-flex flex-column overflow-hidden"
         style={{ minWidth: 0, minHeight: 0 }}
       >
-        {/* Canvas + optional layers sidebar, side by side */}
-        <div className="flex-grow-1 d-flex flex-row overflow-hidden" style={{ minHeight: 0 }}>
+        <div
+          className="flex-grow-1 d-flex flex-row overflow-hidden"
+          style={{ minHeight: 0 }}
+        >
           <div
             className="flex-grow-1 overflow-hidden"
             style={{ background: "#0a0a0f", position: "relative" }}
@@ -323,82 +236,19 @@ export default function CanvasPanel() {
         </div>
 
         {/* Status bar */}
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 12,
-            padding: "3px 10px",
-            background: "#111118",
-            borderTop: "1px solid rgba(255,255,255,0.06)",
-            fontSize: 11,
-            fontFamily: "monospace",
-            color: "rgba(255,255,255,0.4)",
-            flexShrink: 0,
-          }}
-        >
-          <span>{canvas.documentWidth} × {canvas.documentHeight}</span>
-          <span>Zoom: {Math.round(zoom * 100)}%</span>
-          <span>Grid: {canvas.activeGridArea.width} × {canvas.activeGridArea.height}</span>
-          {canvas.activeLayer && <span>Layer: {canvas.activeLayer.name}</span>}
-          <span
-            style={{
-              display: "inline-flex",
-              alignItems: "center",
-              gap: 4,
-              color: canvasSync.connected
-                ? "rgba(0,200,100,0.7)"
-                : "rgba(255,150,50,0.6)",
-            }}
-          >
-            <span
-              style={{
-                width: 6,
-                height: 6,
-                borderRadius: "50%",
-                background: canvasSync.connected
-                  ? "rgb(0,200,100)"
-                  : "rgb(255,150,50)",
-                display: "inline-block",
-              }}
-            />
-            {canvasSync.connected ? "Live" : "Reconnecting…"}
-          </span>
-        </div>
+        <CanvasStatusBar
+          documentWidth={canvas.documentWidth}
+          documentHeight={canvas.documentHeight}
+          zoom={zoom}
+          gridWidth={canvas.activeGridArea.width}
+          gridHeight={canvas.activeGridArea.height}
+          activeLayer={canvas.activeLayer}
+          connected={canvasSync.connected}
+        />
       </div>
 
       {dock === "bottom" && (
-        <ToolBar
-          activeTool={canvas.activeTool}
-          brushSize={canvas.brushSize}
-          brushColor={canvas.brushColor}
-          showGrid={showGrid}
-          snapToGrid={canvas.snapToGrid}
-          zoom={zoom}
-          activeGridArea={canvas.activeGridArea}
-          gridLocked={gridLocked}
-          dock={dock}
-          onSetActiveTool={canvas.setActiveTool}
-          onSetBrushSize={canvas.setBrushSize}
-          onSetBrushColor={canvas.setBrushColor}
-          onToggleGrid={() => setShowGrid((v) => !v)}
-          onToggleSnap={() => canvas.setSnapToGrid(!canvas.snapToGrid)}
-          onZoomIn={() => canvasHandleRef.current?.zoomIn()}
-          onZoomOut={() => canvasHandleRef.current?.zoomOut()}
-          onZoomReset={() => canvasHandleRef.current?.zoomReset()}
-          onCenterView={() => canvasHandleRef.current?.centerView()}
-          onSetGridArea={canvas.setActiveGridArea}
-          onToggleGridLock={() => setGridLocked((v) => !v)}
-          onOpenSettings={() => setShowSettings(true)}
-          onSetDock={handleSetDock}
-          onUndo={canvas.undo}
-          onRedo={canvas.redo}
-          onNewDocument={handleNewDocument}
-          onClearMask={canvas.clearMask}
-          hasMaskStrokes={canvas.maskStrokes.length > 0}
-          showLayers={showLayers}
-          onToggleLayers={() => setShowLayers((v) => !v)}
-        />
+        <ToolBar {...sharedToolbarProps} dock="bottom" />
       )}
 
       {/* Modals */}

--- a/airunner_web_client/src/components/panels/ImageBrowserPanel.tsx
+++ b/airunner_web_client/src/components/panels/ImageBrowserPanel.tsx
@@ -1,8 +1,8 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Spinner from "react-bootstrap/Spinner";
 import { BASE_URL } from "../../types/api";
-import type { ImageDateInfo, ImageInfo } from "../../api/client";
-import { deleteImage, renameImage } from "../../api/client";
+import type { ImageInfo } from "../../api/client";
+import { deleteImage } from "../../api/client";
 import {
   getLocalImages,
   deleteLocalImage,
@@ -14,13 +14,18 @@ import ImagePreviewModal from "./image-browser/ImagePreviewModal";
 import ServerImageRow from "./image-browser/ServerImageRow";
 import LocalImageRow from "./image-browser/LocalImageRow";
 import ImageBrowserFooter from "./image-browser/ImageBrowserFooter";
+import ImageDateSelector from "./image-browser/ImageDateSelector";
+import { useInfiniteScroll } from "./image-browser/useInfiniteScroll";
+import { useImageBrowserSSE } from "./image-browser/useImageBrowserSSE";
 
 const PAGE_SIZE = 20;
 
 export { saveLocalImage, getLocalImages, type LocalImageEntry };
 
 export default function ImageBrowserPanel() {
-  const [dates, setDates] = useState<ImageDateInfo[]>([]);
+  const [dates, setDates] = useState<
+    { value: string; label: string }[]
+  >([]);
   const [selectedDate, setSelectedDate] = useState<string | null>(() => {
     try {
       return localStorage.getItem(LS_DATE_KEY);
@@ -38,8 +43,6 @@ export default function ImageBrowserPanel() {
   const [showLocal, setShowLocal] = useState(false);
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
   const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
-
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     setLocalImages(getLocalImages());
@@ -103,53 +106,29 @@ export default function ImageBrowserPanel() {
     loadImages(selectedDate, 0, false);
   }, [selectedDate, loadImages]);
 
-  useEffect(() => {
-    if (!hasMore || loadingImages || !sentinelRef.current) return;
-    const sentinel = sentinelRef.current;
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries[0].isIntersecting && hasMore && selectedDate) {
-          loadImages(selectedDate, offset, true);
-        }
-      },
-      { rootMargin: "200px" },
-    );
-    observer.observe(sentinel);
-    return () => observer.disconnect();
+  const loadMore = useCallback(() => {
+    if (hasMore && !loadingImages && selectedDate) {
+      loadImages(selectedDate, offset, true);
+    }
   }, [hasMore, loadingImages, selectedDate, offset, loadImages]);
 
-  useEffect(() => {
-    const eventSource = new EventSource(
-      `${BASE_URL}/api/v1/art/images/watch`,
-    );
-    eventSource.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        if (data.type === "reload") {
-          loadDates();
-          setServerImages([]);
-          setOffset(0);
-          setHasMore(true);
-          if (selectedDate) {
-            loadImages(selectedDate, 0, false);
-          }
-          setLocalImages(getLocalImages());
-        }
-      } catch {
-        // ignore malformed events
-      }
-    };
-    eventSource.onerror = () => {
-      // The browser will auto-reconnect
-    };
-    return () => {
-      eventSource.close();
-    };
+  const sentinelRef = useInfiniteScroll(loadMore, hasMore && !loadingImages);
+
+  const handleSSEReload = useCallback(() => {
+    loadDates();
+    setServerImages([]);
+    setOffset(0);
+    setHasMore(true);
+    if (selectedDate) {
+      loadImages(selectedDate, 0, false);
+    }
+    setLocalImages(getLocalImages());
   }, [loadDates, selectedDate, loadImages]);
 
-  const handleDateChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    const val = e.target.value || null;
-    if (val === "__local__") {
+  useImageBrowserSSE(handleSSEReload);
+
+  const handleDateChange = (val: string | null, isLocal: boolean) => {
+    if (isLocal) {
       setShowLocal(true);
       return;
     }
@@ -223,31 +202,17 @@ export default function ImageBrowserPanel() {
     );
   }
 
-  const hasLocalImages = localImages.length > 0;
-
   return (
     <div className="p-2 d-flex flex-column h-100">
       <h6 className="text-muted mb-2">Image Browser</h6>
 
-      <select
-        className="form-select form-select-sm mb-2"
-        value={showLocal ? "__local__" : selectedDate ?? ""}
+      <ImageDateSelector
+        dates={dates}
+        selectedDate={selectedDate}
+        showLocal={showLocal}
+        localImageCount={localImages.length}
         onChange={handleDateChange}
-      >
-        {hasLocalImages && (
-          <option value="__local__">
-            Local Storage ({localImages.length})
-          </option>
-        )}
-        {dates.length === 0 && !hasLocalImages && (
-          <option value="">No images found</option>
-        )}
-        {dates.map((d) => (
-          <option key={d.value} value={d.value}>
-            {d.label}
-          </option>
-        ))}
-      </select>
+      />
 
       <div className="flex-grow-1 overflow-auto">
         {showLocal ? (

--- a/airunner_web_client/src/components/panels/art-model/ArtModelSliders.tsx
+++ b/airunner_web_client/src/components/panels/art-model/ArtModelSliders.tsx
@@ -1,0 +1,91 @@
+import SliderWithSpinbox from "../SliderWithSpinbox";
+
+export interface ArtModelSlidersProps {
+  nSamples: number;
+  imagesPerBatch: number;
+  steps: number;
+  cfgScale: number;
+  width: number;
+  height: number;
+  onNSamplesChange: (v: number) => void;
+  onImagesPerBatchChange: (v: number) => void;
+  onStepsChange: (v: number) => void;
+  onCfgScaleChange: (v: number) => void;
+  onWidthChange: (v: number) => void;
+  onHeightChange: (v: number) => void;
+}
+
+export default function ArtModelSliders({
+  nSamples,
+  imagesPerBatch,
+  steps,
+  cfgScale,
+  width,
+  height,
+  onNSamplesChange,
+  onImagesPerBatchChange,
+  onStepsChange,
+  onCfgScaleChange,
+  onWidthChange,
+  onHeightChange,
+}: ArtModelSlidersProps) {
+  return (
+    <>
+      <SliderWithSpinbox
+        label="Samples"
+        value={nSamples}
+        min={1}
+        max={1000}
+        step={1}
+        defaultValue={1}
+        onChange={onNSamplesChange}
+      />
+      <SliderWithSpinbox
+        label="Batch"
+        value={imagesPerBatch}
+        min={1}
+        max={6}
+        step={1}
+        defaultValue={1}
+        onChange={onImagesPerBatchChange}
+      />
+      <SliderWithSpinbox
+        label="Steps"
+        value={steps}
+        min={1}
+        max={150}
+        step={1}
+        defaultValue={20}
+        onChange={onStepsChange}
+      />
+      <SliderWithSpinbox
+        label="CFG"
+        value={cfgScale}
+        min={1}
+        max={30}
+        step={0.5}
+        displayAsFloat
+        defaultValue={7.5}
+        onChange={onCfgScaleChange}
+      />
+      <SliderWithSpinbox
+        label="Width"
+        value={width}
+        min={64}
+        max={4096}
+        step={64}
+        defaultValue={1024}
+        onChange={onWidthChange}
+      />
+      <SliderWithSpinbox
+        label="Height"
+        value={height}
+        min={64}
+        max={4096}
+        step={64}
+        defaultValue={1024}
+        onChange={onHeightChange}
+      />
+    </>
+  );
+}

--- a/airunner_web_client/src/components/panels/art-model/ArtModelStorage.ts
+++ b/airunner_web_client/src/components/panels/art-model/ArtModelStorage.ts
@@ -1,0 +1,21 @@
+export const LS_KEY = "airunner_art_settings";
+
+export function saveToStorage(key: string, val: number) {
+  try {
+    const data = JSON.parse(localStorage.getItem(LS_KEY) || "{}");
+    data[key] = val;
+    localStorage.setItem(LS_KEY, JSON.stringify(data));
+  } catch {
+    /* */
+  }
+}
+
+export function loadFromStorage(key: string, fallback: number): number {
+  try {
+    const data = JSON.parse(localStorage.getItem(LS_KEY) || "{}");
+    const v = data[key];
+    return v !== undefined ? Number(v) : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/airunner_web_client/src/components/panels/art-model/VRAMEstimate.tsx
+++ b/airunner_web_client/src/components/panels/art-model/VRAMEstimate.tsx
@@ -1,0 +1,23 @@
+import ProgressBar from "react-bootstrap/ProgressBar";
+
+export default function VRAMEstimate({
+  vramGb,
+}: {
+  vramGb: number | null;
+}) {
+  if (vramGb === null || vramGb <= 0) return null;
+
+  return (
+    <div className="mt-2 mb-2">
+      <small style={{ color: "var(--theme-text-secondary)" }}>
+        Estimated VRAM: {vramGb.toFixed(1)} GB
+      </small>
+      <ProgressBar
+        now={Math.min((vramGb / 24) * 100, 100)}
+        variant={vramGb > 20 ? "danger" : "success"}
+        className="mt-1"
+        style={{ height: 6 }}
+      />
+    </div>
+  );
+}

--- a/airunner_web_client/src/components/panels/art-prompt/ArtPromptStorage.ts
+++ b/airunner_web_client/src/components/panels/art-prompt/ArtPromptStorage.ts
@@ -1,0 +1,33 @@
+export const STORAGE_KEY = "airunner_art_prompt_data";
+
+export interface PromptData {
+  prompt: string;
+  negative_prompt: string;
+  secondary_prompt: string;
+  secondary_negative_prompt: string;
+}
+
+export const DEFAULT_PROMPT_DATA: PromptData = {
+  prompt: "",
+  negative_prompt: "",
+  secondary_prompt: "",
+  secondary_negative_prompt: "",
+};
+
+export function loadPromptData(): PromptData {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) return JSON.parse(raw) as PromptData;
+  } catch {
+    /* ignore */
+  }
+  return { ...DEFAULT_PROMPT_DATA };
+}
+
+export function savePromptData(data: Record<string, string>) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    /* ignore */
+  }
+}

--- a/airunner_web_client/src/components/panels/art-prompt/useArtGeneration.ts
+++ b/airunner_web_client/src/components/panels/art-prompt/useArtGeneration.ts
@@ -1,0 +1,73 @@
+import { useState, useRef, useCallback } from "react";
+import {
+  startArtGeneration,
+  getArtJobStatus,
+} from "../../../api/client";
+
+export function useArtGeneration() {
+  const [generating, setGenerating] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const jobIdRef = useRef<string | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const handleCancel = useCallback(() => {
+    if (pollRef.current) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    jobIdRef.current = null;
+    setGenerating(false);
+    setProgress(0);
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (params: {
+      prompt: string;
+      negativePrompt?: string;
+      artModel?: string;
+      artVersion?: string;
+      scheduler?: string;
+    }) => {
+      const { prompt, negativePrompt, artModel, artVersion, scheduler } =
+        params;
+      if (generating || !prompt.trim()) return;
+      setGenerating(true);
+      setProgress(0);
+      try {
+        const resp = await startArtGeneration({
+          prompt: prompt.trim(),
+          negative_prompt: negativePrompt?.trim() || undefined,
+          model: artModel || undefined,
+          version: artVersion || undefined,
+          scheduler: scheduler || undefined,
+          num_images: 1,
+        });
+        jobIdRef.current = resp.job_id;
+        pollRef.current = setInterval(async () => {
+          try {
+            const status = await getArtJobStatus(resp.job_id);
+            setProgress(status.progress ?? 0);
+            if (
+              status.status === "complete" ||
+              status.status === "failed"
+            ) {
+              handleCancel();
+            }
+          } catch {
+            // keep polling
+          }
+        }, 1000);
+      } catch {
+        setGenerating(false);
+      }
+    },
+    [generating, handleCancel],
+  );
+
+  return {
+    generating,
+    progress,
+    handleSubmit,
+    handleCancel,
+  };
+}

--- a/airunner_web_client/src/components/panels/canvas/CanvasPanelTypes.ts
+++ b/airunner_web_client/src/components/panels/canvas/CanvasPanelTypes.ts
@@ -1,0 +1,16 @@
+/** Pending image-drop payload awaiting resize-mode selection. */
+export interface PendingDrop {
+  base64: string;
+  x: number;
+  y: number;
+  naturalW: number;
+  naturalH: number;
+}
+
+/** Magic-byte signatures for common image formats. */
+export const IMAGE_MAGIC: [number[], number][] = [
+  [[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], 8], // PNG
+  [[0xFF, 0xD8, 0xFF],                                     3], // JPEG
+  [[0x47, 0x49, 0x46, 0x38],                               4], // GIF87a / GIF89a
+  [[0x42, 0x4D],                                            2], // BMP
+];

--- a/airunner_web_client/src/components/panels/canvas/CanvasStatusBar.tsx
+++ b/airunner_web_client/src/components/panels/canvas/CanvasStatusBar.tsx
@@ -1,0 +1,66 @@
+import type { CanvasLayer } from "../../../features/canvas/useCanvasState";
+
+export interface CanvasStatusBarProps {
+  documentWidth: number;
+  documentHeight: number;
+  zoom: number;
+  gridWidth: number;
+  gridHeight: number;
+  activeLayer: CanvasLayer | null;
+  connected: boolean;
+}
+
+export default function CanvasStatusBar({
+  documentWidth,
+  documentHeight,
+  zoom,
+  gridWidth,
+  gridHeight,
+  activeLayer,
+  connected,
+}: CanvasStatusBarProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+        padding: "3px 10px",
+        background: "#111118",
+        borderTop: "1px solid rgba(255,255,255,0.06)",
+        fontSize: 11,
+        fontFamily: "monospace",
+        color: "rgba(255,255,255,0.4)",
+        flexShrink: 0,
+      }}
+    >
+      <span>{documentWidth} &times; {documentHeight}</span>
+      <span>Zoom: {Math.round(zoom * 100)}%</span>
+      <span>Grid: {gridWidth} &times; {gridHeight}</span>
+      {activeLayer && <span>Layer: {activeLayer.name}</span>}
+      <span
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          gap: 4,
+          color: connected
+            ? "rgba(0,200,100,0.7)"
+            : "rgba(255,150,50,0.6)",
+        }}
+      >
+        <span
+          style={{
+            width: 6,
+            height: 6,
+            borderRadius: "50%",
+            background: connected
+              ? "rgb(0,200,100)"
+              : "rgb(255,150,50)",
+            display: "inline-block",
+          }}
+        />
+        {connected ? "Live" : "Reconnecting\u2026"}
+      </span>
+    </div>
+  );
+}

--- a/airunner_web_client/src/components/panels/canvas/useCanvasImageDrop.ts
+++ b/airunner_web_client/src/components/panels/canvas/useCanvasImageDrop.ts
@@ -1,0 +1,216 @@
+import { useState, useCallback, useEffect } from "react";
+import Konva from "konva";
+import type { PendingDrop } from "./CanvasPanelTypes";
+import { IMAGE_MAGIC } from "./CanvasPanelTypes";
+import { fitDimensions } from "../../../features/canvas/ImageDropModal";
+import type { DropResizeMode } from "../../../features/canvas/ImageDropModal";
+
+export function useCanvasImageDrop(
+  stageRef: React.RefObject<Konva.Stage>,
+) {
+  const [pendingDrop, setPendingDrop] = useState<PendingDrop | null>(
+    null,
+  );
+  const [showDropModal, setShowDropModal] = useState(false);
+
+  const canvasDropPos = useCallback(
+    (clientX: number, clientY: number) => {
+      const stage = stageRef.current;
+      if (!stage) return { x: 0, y: 0 };
+      const rect = stage.container().getBoundingClientRect();
+      const scale = stage.scaleX();
+      return {
+        x: (clientX - rect.left - stage.x()) / scale,
+        y: (clientY - rect.top - stage.y()) / scale,
+      };
+    },
+    [stageRef],
+  );
+
+  const queueDrop = useCallback(
+    (dataUrl: string, x: number, y: number) => {
+      const img = new Image();
+      img.onload = () => {
+        setPendingDrop({
+          base64: dataUrl,
+          x,
+          y,
+          naturalW: img.naturalWidth,
+          naturalH: img.naturalHeight,
+        });
+        setShowDropModal(true);
+      };
+      img.src = dataUrl;
+    },
+    [],
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  }, []);
+
+  /** Check whether a file is an image using MIME type (fast) or magic bytes. */
+  const isImageFile = useCallback(
+    async (file: File): Promise<boolean> => {
+      if (file.type.startsWith("image/")) return true;
+      try {
+        const buf = await file.slice(0, 8).arrayBuffer();
+        const header = new Uint8Array(buf);
+        return IMAGE_MAGIC.some(([sig, len]) =>
+          sig.every((byte, i) => header[i] === byte),
+        );
+      } catch {
+        return false;
+      }
+    },
+    [],
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const { x, y } = canvasDropPos(e.clientX, e.clientY);
+
+      const file = e.dataTransfer.files[0];
+      if (file) {
+        isImageFile(file).then((isImage) => {
+          if (!isImage) {
+            const imageUrl = e.dataTransfer.getData("text/image-url");
+            if (imageUrl) {
+              fetch(imageUrl)
+                .then((r) => r.blob())
+                .then((blob) => {
+                  const r2 = new FileReader();
+                  r2.onload = (ev) => {
+                    const dataUrl = ev.target?.result as string;
+                    if (dataUrl) queueDrop(dataUrl, x, y);
+                  };
+                  r2.readAsDataURL(blob);
+                })
+                .catch(() => {
+                  /* silently ignore */
+                });
+            }
+            return;
+          }
+          const reader = new FileReader();
+          reader.onload = (ev) => {
+            const dataUrl = ev.target?.result as string;
+            if (dataUrl) queueDrop(dataUrl, x, y);
+          };
+          reader.readAsDataURL(file);
+        });
+        return;
+      }
+
+      const imageUrl = e.dataTransfer.getData("text/image-url");
+      if (imageUrl) {
+        fetch(imageUrl)
+          .then((r) => r.blob())
+          .then((blob) => {
+            const reader = new FileReader();
+            reader.onload = (ev) => {
+              const dataUrl = ev.target?.result as string;
+              if (dataUrl) queueDrop(dataUrl, x, y);
+            };
+            reader.readAsDataURL(blob);
+          })
+          .catch(() => {
+            /* silently ignore */
+          });
+      }
+    },
+    [canvasDropPos, queueDrop, isImageFile],
+  );
+
+  const handleDropConfirm = useCallback(
+    (
+      mode: DropResizeMode,
+      pendingDrop: PendingDrop,
+      activeGridArea: { width: number; height: number },
+      documentWidth: number,
+      documentHeight: number,
+      placeImageFn: (
+        base64: string,
+        x: number,
+        y: number,
+        w: number,
+        h: number,
+      ) => void,
+    ) => {
+      const { base64, x, y, naturalW, naturalH } = pendingDrop;
+      let w = naturalW;
+      let h = naturalH;
+      if (mode === "fit-grid") {
+        const fit = fitDimensions(
+          naturalW,
+          naturalH,
+          activeGridArea.width,
+          activeGridArea.height,
+        );
+        w = fit.w;
+        h = fit.h;
+      } else if (mode === "fit-canvas") {
+        const fit = fitDimensions(
+          naturalW,
+          naturalH,
+          documentWidth,
+          documentHeight,
+        );
+        w = fit.w;
+        h = fit.h;
+      }
+      placeImageFn(
+        base64,
+        Math.max(0, x - w / 2),
+        Math.max(0, y - h / 2),
+        w,
+        h,
+      );
+      setPendingDrop(null);
+    },
+    [],
+  );
+
+  /** Listen for the "canvas-place-image" event fired by ServerImageRow */
+  const useCanvasPlaceImage = (queueDropFn: typeof queueDrop) => {
+    useEffect(() => {
+      const handler = (e: Event) => {
+        const { imageUrl } = (
+          e as CustomEvent<{ imageUrl: string }>
+        ).detail;
+        if (!imageUrl) return;
+        fetch(imageUrl)
+          .then((r) => r.blob())
+          .then((blob) => {
+            const reader = new FileReader();
+            reader.onload = (ev) => {
+              const dataUrl = ev.target?.result as string;
+              if (dataUrl) queueDropFn(dataUrl, 0, 0);
+            };
+            reader.readAsDataURL(blob);
+          })
+          .catch(() => {
+            /* silently ignore */
+          });
+      };
+      window.addEventListener("canvas-place-image", handler);
+      return () =>
+        window.removeEventListener("canvas-place-image", handler);
+    }, [queueDropFn]);
+  };
+
+  return {
+    pendingDrop,
+    showDropModal,
+    setShowDropModal,
+    canvasDropPos,
+    queueDrop,
+    handleDragOver,
+    isImageFile,
+    handleDrop,
+    handleDropConfirm,
+    useCanvasPlaceImage,
+  };
+}

--- a/airunner_web_client/src/components/panels/image-browser/ImageDateSelector.tsx
+++ b/airunner_web_client/src/components/panels/image-browser/ImageDateSelector.tsx
@@ -1,0 +1,48 @@
+import type { ImageDateInfo } from "../../../api/client";
+
+export default function ImageDateSelector({
+  dates,
+  selectedDate,
+  showLocal,
+  localImageCount,
+  onChange,
+}: {
+  dates: ImageDateInfo[];
+  selectedDate: string | null;
+  showLocal: boolean;
+  localImageCount: number;
+  onChange: (value: string | null, isLocal: boolean) => void;
+}) {
+  const hasLocalImages = localImageCount > 0;
+
+  const handleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value || null;
+    if (val === "__local__") {
+      onChange(null, true);
+      return;
+    }
+    onChange(val, false);
+  };
+
+  return (
+    <select
+      className="form-select form-select-sm mb-2"
+      value={showLocal ? "__local__" : selectedDate ?? ""}
+      onChange={handleChange}
+    >
+      {hasLocalImages && (
+        <option value="__local__">
+          Local Storage ({localImageCount})
+        </option>
+      )}
+      {dates.length === 0 && !hasLocalImages && (
+        <option value="">No images found</option>
+      )}
+      {dates.map((d) => (
+        <option key={d.value} value={d.value}>
+          {d.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/airunner_web_client/src/components/panels/image-browser/useImageBrowserSSE.ts
+++ b/airunner_web_client/src/components/panels/image-browser/useImageBrowserSSE.ts
@@ -1,0 +1,28 @@
+import { useEffect } from "react";
+import { BASE_URL } from "../../../types/api";
+
+export function useImageBrowserSSE(
+  onReload: () => void,
+) {
+  useEffect(() => {
+    const eventSource = new EventSource(
+      `${BASE_URL}/api/v1/art/images/watch`,
+    );
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        if (data.type === "reload") {
+          onReload();
+        }
+      } catch {
+        // ignore malformed events
+      }
+    };
+    eventSource.onerror = () => {
+      // The browser will auto-reconnect
+    };
+    return () => {
+      eventSource.close();
+    };
+  }, [onReload]);
+}

--- a/airunner_web_client/src/components/panels/image-browser/useInfiniteScroll.ts
+++ b/airunner_web_client/src/components/panels/image-browser/useInfiniteScroll.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+
+export function useInfiniteScroll(
+  callback: () => void,
+  enabled: boolean,
+) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !sentinelRef.current) return;
+    const sentinel = sentinelRef.current;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0].isIntersecting) {
+          callback();
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [enabled, callback]);
+
+  return sentinelRef;
+}


### PR DESCRIPTION
CanvasPanel.tsx (437->287 lines):
- Extract CanvasPanelTypes (PendingDrop, IMAGE_MAGIC)
- Extract CanvasStatusBar component
- Extract useCanvasImageDrop hook

ArtModelPanel.tsx (336->290 lines):
- Extract ArtModelStorage (saveToStorage/loadFromStorage)
- Extract VRAMEstimate component
- Extract ArtModelSliders component

ArtPromptPanel.tsx (311->250 lines):
- Extract ArtPromptStorage (PromptData, loadPromptData/savePromptData)
- Extract useArtGeneration hook

ImageBrowserPanel.tsx (322->287 lines):
- Extract ImageDateSelector component
- Extract useInfiniteScroll hook
- Extract useImageBrowserSSE hook