### PR TITLE
restore: bring back build scripts deleted in PR #1992

### DIFF
--- a/package/build_bundle.ps1
+++ b/package/build_bundle.ps1
@@ -1,0 +1,199 @@
+<#
+.SYNOPSIS
+    Build the AI Runner end-user bundle for Windows.
+
+.DESCRIPTION
+    This script mirrors the CI pipeline for Windows (NVIDIA CUDA) builds.
+    Prerequisites on the build host:
+      - CUDA toolkit 12.x (matching the version pinned in package/versions.txt)
+      - CMake >= 3.24
+      - Visual Studio 2022 with "Desktop development with C++" workload
+      - Node.js >= 20
+      - curl, tar
+#>
+
+$ErrorActionPreference = "Stop"
+$ROOT_DIR = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$ELECTRON_DIR = Join-Path $ROOT_DIR "electron"
+$WEB_DIR = Join-Path $ROOT_DIR "client"
+$SERVICES_DIR = Join-Path $ROOT_DIR "server"
+$BUILD_DIR = Join-Path $ROOT_DIR "build\bundle"
+$RESOURCES_DIR = Join-Path $ELECTRON_DIR "resources"
+
+# ---------------------------------------------------------------------------
+# Read pinned versions
+# ---------------------------------------------------------------------------
+$VERSIONS_FILE = Join-Path $ROOT_DIR "package\versions.txt"
+$VERSIONS = @{}
+Get-Content $VERSIONS_FILE | ForEach-Object {
+    if ($_ -match "^([^#=]+)=(.+)$") {
+        $VERSIONS[$matches[1]] = $matches[2]
+    }
+}
+
+$PYTHON_BUILD_STANDALONE_VERSION = $VERSIONS["python-build-standalone"]
+$LLAMA_CPP_TAG = $VERSIONS["llama.cpp"]
+$WHISPER_CPP_TAG = $VERSIONS["whisper.cpp"]
+$TORCH_INDEX = $VERSIONS["torch"]
+
+Write-Host "=== AI Runner Bundle Build (Windows) ===" -ForegroundColor Green
+
+# ---------------------------------------------------------------------------
+# Step 0 – Clean and prepare directories
+# ---------------------------------------------------------------------------
+if (Test-Path $BUILD_DIR) { Remove-Item -Recurse -Force $BUILD_DIR }
+if (Test-Path $RESOURCES_DIR) { Remove-Item -Recurse -Force $RESOURCES_DIR }
+New-Item -ItemType Directory -Force -Path "$BUILD_DIR\python"
+New-Item -ItemType Directory -Force -Path "$RESOURCES_DIR\python"
+New-Item -ItemType Directory -Force -Path "$RESOURCES_DIR\web"
+
+# ---------------------------------------------------------------------------
+# Step 1 – Download and extract python-build-standalone
+# ---------------------------------------------------------------------------
+Write-Host "Downloading python-build-standalone ${PYTHON_BUILD_STANDALONE_VERSION}..." -ForegroundColor Green
+
+$PYTHON_ARCHIVE = "cpython-3.13.${PYTHON_BUILD_STANDALONE_VERSION}-x86_64-pc-windows-msvc-install_only.tar.gz"
+$PYTHON_URL = "https://github.com/indygreg/python-build-standalone/releases/download/${PYTHON_BUILD_STANDALONE_VERSION}/${PYTHON_ARCHIVE}"
+$PYTHON_ARCHIVE_PATH = Join-Path $BUILD_DIR $PYTHON_ARCHIVE
+
+if (-not (Test-Path $PYTHON_ARCHIVE_PATH)) {
+    Invoke-WebRequest -Uri $PYTHON_URL -OutFile $PYTHON_ARCHIVE_PATH
+}
+
+Write-Host "Extracting python-build-standalone..." -ForegroundColor Green
+tar -xzf $PYTHON_ARCHIVE_PATH -C $BUILD_DIR
+$EMBEDDED_PYTHON = Join-Path $BUILD_DIR "python"
+
+# Verify
+& "$EMBEDDED_PYTHON\python.exe" --version
+
+# ---------------------------------------------------------------------------
+# Step 2 – Install Python dependencies into the embedded runtime
+# ---------------------------------------------------------------------------
+Write-Host "Installing Python dependencies..." -ForegroundColor Green
+
+& "$EMBEDDED_PYTHON\python.exe" -m pip install --upgrade pip setuptools wheel
+
+# Install PyTorch with CUDA support.
+& "$EMBEDDED_PYTHON\python.exe" -m pip install `
+    torch torchvision torchaudio `
+    --index-url "https://download.pytorch.org/whl/${TORCH_INDEX}"
+
+# Install the airunner services package with the headless profile.
+& "$EMBEDDED_PYTHON\python.exe" -m pip install `
+    -e "${SERVICES_DIR}[headless]"
+
+# ---------------------------------------------------------------------------
+# Step 3 – Build llama.cpp from source with CUDA
+# ---------------------------------------------------------------------------
+Write-Host "Building llama.cpp ${LLAMA_CPP_TAG} with CUDA..." -ForegroundColor Green
+
+$LLAMA_SRC = Join-Path $BUILD_DIR "llama.cpp"
+if (-not (Test-Path $LLAMA_SRC)) {
+    git clone --depth 1 --branch $LLAMA_CPP_TAG `
+        "https://github.com/ggerganov/llama.cpp.git" $LLAMA_SRC
+}
+
+cmake -S $LLAMA_SRC -B "$LLAMA_SRC/build" `
+    -DGGML_CUDA=on `
+    -DGGML_CUDA_ARCHITECTURES=86 `
+    -DBUILD_SHARED_LIBS=on `
+    -DLLAMA_BUILD_TESTS=off `
+    -DLLAMA_BUILD_EXAMPLES=off `
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake --build "$LLAMA_SRC/build" --config Release -j $env:NUMBER_OF_PROCESSORS
+
+# Find llama-cpp-python package directory.
+$LLAMA_CPP_DIR = Get-ChildItem -Path $EMBEDDED_PYTHON -Recurse -Directory `
+    -Filter "llama_cpp" | Where-Object { $_.FullName -match "site-packages\\llama_cpp$" } |
+    Select-Object -First 1
+
+if ($LLAMA_CPP_DIR) {
+    Write-Host "Placing llama.dll into $($LLAMA_CPP_DIR.FullName)\lib\" -ForegroundColor Green
+    New-Item -ItemType Directory -Force -Path "$($LLAMA_CPP_DIR.FullName)\lib\"
+    Copy-Item "$LLAMA_SRC\build\bin\Release\llama.dll" "$($LLAMA_CPP_DIR.FullName)\lib\"
+} else {
+    Write-Host "Warning: Could not find llama_cpp site-package dir." -ForegroundColor Yellow
+    Copy-Item "$LLAMA_SRC\build\bin\Release\llama.dll" "$EMBEDDED_PYTHON\libs\"
+}
+
+# ---------------------------------------------------------------------------
+# Step 4 – Build whisper.cpp from source with CUDA
+# ---------------------------------------------------------------------------
+Write-Host "Building whisper.cpp ${WHISPER_CPP_TAG} with CUDA..." -ForegroundColor Green
+
+$WHISPER_SRC = Join-Path $BUILD_DIR "whisper.cpp"
+if (-not (Test-Path $WHISPER_SRC)) {
+    git clone --depth 1 --branch $WHISPER_CPP_TAG `
+        "https://github.com/ggerganov/whisper.cpp.git" $WHISPER_SRC
+}
+
+cmake -S $WHISPER_SRC -B "$WHISPER_SRC/build" `
+    -DGGML_CUDA=on `
+    -DGGML_CUDA_ARCHITECTURES=86 `
+    -DBUILD_SHARED_LIBS=on `
+    -DWHISPER_BUILD_TESTS=off `
+    -DWHISPER_BUILD_EXAMPLES=off `
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake --build "$WHISPER_SRC/build" --config Release -j $env:NUMBER_OF_PROCESSORS
+
+$WHISPER_CPP_DIR = Get-ChildItem -Path $EMBEDDED_PYTHON -Recurse -Directory `
+    -Filter "whisper_cpp" | Where-Object { $_.FullName -match "site-packages\\whisper_cpp$" } |
+    Select-Object -First 1
+
+if ($WHISPER_CPP_DIR) {
+    Write-Host "Placing whisper.dll into $($WHISPER_CPP_DIR.FullName)\lib\" -ForegroundColor Green
+    New-Item -ItemType Directory -Force -Path "$($WHISPER_CPP_DIR.FullName)\lib\"
+    Copy-Item "$WHISPER_SRC\build\bin\Release\whisper.dll" "$($WHISPER_CPP_DIR.FullName)\lib\"
+} else {
+    Write-Host "Warning: Could not find whisper_cpp site-package dir." -ForegroundColor Yellow
+    Copy-Item "$WHISPER_SRC\build\bin\Release\whisper.dll" "$EMBEDDED_PYTHON\libs\"
+}
+
+# ---------------------------------------------------------------------------
+# Step 5 – Build the React frontend
+# ---------------------------------------------------------------------------
+Write-Host "Building React frontend..." -ForegroundColor Green
+
+if (-not (Test-Path "$WEB_DIR\node_modules")) {
+    Push-Location $WEB_DIR
+    npm ci
+    Pop-Location
+}
+
+$env:VITE_API_BASE_URL = "http://localhost:8080"
+Push-Location $WEB_DIR
+npm run build
+Pop-Location
+
+# ---------------------------------------------------------------------------
+# Step 6 – Copy build artifacts into electron/resources/
+# ---------------------------------------------------------------------------
+Write-Host "Copying build artifacts into electron/resources/..." -ForegroundColor Green
+
+Copy-Item -Recurse "$EMBEDDED_PYTHON\*" "$RESOURCES_DIR\python\"
+Copy-Item -Recurse "$WEB_DIR\dist\*" "$RESOURCES_DIR\web\"
+
+# ---------------------------------------------------------------------------
+# Step 7 – Build the Electron installer
+# ---------------------------------------------------------------------------
+Write-Host "Building Electron installer..." -ForegroundColor Green
+
+if (-not (Test-Path "$ELECTRON_DIR\node_modules")) {
+    Push-Location $ELECTRON_DIR
+    npm ci
+    Pop-Location
+}
+
+Push-Location $ELECTRON_DIR
+npm run build:windows
+Pop-Location
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+Write-Host "Bundle build complete!" -ForegroundColor Green
+Write-Host "Installer artifacts are in $ELECTRON_DIR\dist\" -ForegroundColor Green
+Get-ChildItem "$ELECTRON_DIR\dist\*.exe"

--- a/package/build_bundle.sh
+++ b/package/build_bundle.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+#
+# build_bundle.sh – Build the AI Runner end-user bundle for Linux.
+#
+# Prerequisites on the build host:
+#   - CUDA toolkit 12.x (matching the version pinned in package/versions.txt)
+#   - CMake >= 3.24
+#   - curl, tar, gzip
+#   - Node.js >= 20 (for Electron and React frontend build)
+#
+# This script mirrors the CI pipeline steps and is intended for local
+# testing by developers who have the required toolchain installed.
+#
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ELECTRON_DIR="${ROOT_DIR}/electron"
+WEB_DIR="${ROOT_DIR}/client"
+SERVICES_DIR="${ROOT_DIR}/server"
+BUILD_DIR="${ROOT_DIR}/build/bundle"
+RESOURCES_DIR="${ELECTRON_DIR}/resources"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+fail() { echo -e "${RED}ERROR:${NC} $*" >&2; exit 1; }
+info() { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
+
+# ---------------------------------------------------------------------------
+# Source the pinned versions from versions.txt
+# ----------------------------------------------------------------------------
+VERSIONS_FILE="${ROOT_DIR}/package/versions.txt"
+declare -A VERSIONS
+
+while IFS='=' read -r key value; do
+    [[ -z "$key" || "$key" == \#* ]] && continue
+    VERSIONS["$key"]="$value"
+done < "$VERSIONS_FILE"
+
+PYTHON_VERSION="${VERSIONS[python]}"
+PYTHON_BUILD_STANDALONE_VERSION="${VERSIONS[python-build-standalone]}"
+LLAMA_CPP_TAG="${VERSIONS[llama.cpp]}"
+WHISPER_CPP_TAG="${VERSIONS[whisper.cpp]}"
+TORCH_INDEX="${VERSIONS[torch]}"
+
+# ---------------------------------------------------------------------------
+# Step 0 — Clean and prepare directories
+# ---------------------------------------------------------------------------
+rm -rf "$BUILD_DIR" "$RESOURCES_DIR"
+mkdir -p "$BUILD_DIR" "$RESOURCES_DIR/python" "$RESOURCES_DIR/web"
+
+# ---------------------------------------------------------------------------
+# Step 1 — Download and extract python-build-standalone
+#
+# python-build-standalone is now hosted by astral-sh:
+#   https://github.com/astral-sh/python-build-standalone
+# Release tag is a date stamp (e.g. 20260602).
+# Archive name format: cpython-{ver}+{tag}-{triple}-install_only.tar.gz
+# ---------------------------------------------------------------------------
+info "Downloading python-build-standalone ${PYTHON_BUILD_STANDALONE_VERSION}..."
+
+PYTHON_ARCHIVE="cpython-${PYTHON_VERSION}+${PYTHON_BUILD_STANDALONE_VERSION}-x86_64-unknown-linux-gnu-install_only.tar.gz"
+PYTHON_URL="https://github.com/astral-sh/python-build-standalone/releases/download/${PYTHON_BUILD_STANDALONE_VERSION}/${PYTHON_ARCHIVE}"
+
+if [ ! -f "${BUILD_DIR}/${PYTHON_ARCHIVE}" ]; then
+    info "Fetching ${PYTHON_URL}"
+    curl -fsSL -o "${BUILD_DIR}/${PYTHON_ARCHIVE}" "$PYTHON_URL"
+fi
+
+info "Extracting python-build-standalone..."
+tar -xzf "${BUILD_DIR}/${PYTHON_ARCHIVE}" -C "$BUILD_DIR"
+EMBEDDED_PYTHON="${BUILD_DIR}/python"
+
+# Verify the embedded Python works.
+"${EMBEDDED_PYTHON}/bin/python3" --version
+
+# ---------------------------------------------------------------------------
+# Step 2 — Install Python dependencies into the embedded runtime
+# ---------------------------------------------------------------------------
+info "Installing Python dependencies..."
+
+# pip install first
+"${EMBEDDED_PYTHON}/bin/python3" -m pip install --upgrade pip setuptools wheel
+
+# Install PyTorch with CUDA support first (large download).
+info "Installing PyTorch with CUDA (${TORCH_INDEX})..."
+"${EMBEDDED_PYTHON}/bin/python3" -m pip install \
+    torch torchvision torchaudio \
+    --index-url "https://download.pytorch.org/whl/${TORCH_INDEX}"
+
+# Install the airunner services package with the bundle profile.
+# The "headless" profile includes llm-native, stt-native, art-python, tts-python.
+info "Installing airunner services [headless]..."
+"${EMBEDDED_PYTHON}/bin/python3" -m pip install \
+    -e "${SERVICES_DIR}[headless]"
+
+# ---------------------------------------------------------------------------
+# Step 3 — Build llama.cpp from source with CUDA
+# ---------------------------------------------------------------------------
+info "Building llama.cpp ${LLAMA_CPP_TAG} with CUDA..."
+
+LLAMA_SRC="${BUILD_DIR}/llama.cpp"
+if [ ! -d "$LLAMA_SRC" ]; then
+    git clone --depth 1 --branch "${LLAMA_CPP_TAG}" \
+        https://github.com/ggerganov/llama.cpp.git "$LLAMA_SRC"
+fi
+
+cmake -S "${LLAMA_SRC}" -B "${LLAMA_SRC}/build" \
+    -DLLAMA_CUBLAS=on \
+    -DCMAKE_CUDA_ARCHITECTURES=86 \
+    -DBUILD_SHARED_LIBS=on \
+    -DLLAMA_BUILD_TESTS=off \
+    -DLLAMA_BUILD_EXAMPLES=off \
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake --build "${LLAMA_SRC}/build" --config Release -j"$(nproc)"
+
+# Find llama-cpp-python package directory inside the embedded Python.
+LLAMA_CPP_LIBDIR=$(find "${EMBEDDED_PYTHON}" -path "*/site-packages/llama_cpp/lib" \
+    -type d 2>/dev/null | head -1)
+
+if [ -n "$LLAMA_CPP_LIBDIR" ]; then
+    info "Placing libllama.so into ${LLAMA_CPP_LIBDIR}/"
+    cp "${LLAMA_SRC}/build/libllama.so" "${LLAMA_CPP_LIBDIR}/"
+else
+    warn "Could not find llama_cpp/lib dir. Placing libllama.so in the Python lib directory as fallback."
+    mkdir -p "${EMBEDDED_PYTHON}/lib"
+    cp "${LLAMA_SRC}/build/libllama.so" "${EMBEDDED_PYTHON}/lib/"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4 — Build whisper.cpp from source with CUDA
+# ---------------------------------------------------------------------------
+info "Building whisper.cpp ${WHISPER_CPP_TAG} with CUDA..."
+
+WHISPER_SRC="${BUILD_DIR}/whisper.cpp"
+if [ ! -d "$WHISPER_SRC" ]; then
+    git clone --depth 1 --branch "${WHISPER_CPP_TAG}" \
+        https://github.com/ggerganov/whisper.cpp.git "$WHISPER_SRC"
+fi
+
+cmake -S "${WHISPER_SRC}" -B "${WHISPER_SRC}/build" \
+    -DGGML_CUDA=on \
+    -DCMAKE_CUDA_ARCHITECTURES=86 \
+    -DBUILD_SHARED_LIBS=on \
+    -DWHISPER_BUILD_TESTS=off \
+    -DWHISPER_BUILD_EXAMPLES=off \
+    -DCMAKE_BUILD_TYPE=Release
+
+cmake --build "${WHISPER_SRC}/build" --config Release -j"$(nproc)"
+
+# Find whisper-cpp Python package directory.
+WHISPER_CPP_LIBDIR=$(find "${EMBEDDED_PYTHON}" -path "*/site-packages/whisper_cpp/lib" \
+    -type d 2>/dev/null | head -1)
+
+if [ -n "$WHISPER_CPP_LIBDIR" ]; then
+    info "Placing libwhisper.so into ${WHISPER_CPP_LIBDIR}/"
+    cp "${WHISPER_SRC}/build/src/libwhisper.so" "${WHISPER_CPP_LIBDIR}/" 2>/dev/null || \
+        cp "${WHISPER_SRC}/build/libwhisper.so" "${WHISPER_CPP_LIBDIR}/"
+else
+    warn "Could not find whisper_cpp/lib dir. Placing libwhisper.so in the Python lib directory as fallback."
+    cp "${WHISPER_SRC}/build/src/libwhisper.so" "${EMBEDDED_PYTHON}/lib/" 2>/dev/null || \
+        cp "${WHISPER_SRC}/build/libwhisper.so" "${EMBEDDED_PYTHON}/lib/"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5 — Generate application icons
+# ---------------------------------------------------------------------------
+info "Generating application icons..."
+
+"${EMBEDDED_PYTHON}/bin/python3" -c "
+from PIL import Image, ImageDraw
+import os
+outdir = '${ROOT_DIR}/packaging/linux'
+os.makedirs(outdir, exist_ok=True)
+for size in [256, 128, 64, 48, 32, 24, 16]:
+    img = Image.new('RGBA', (size, size), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+    margin = max(2, size // 20)
+    draw.rounded_rectangle(
+        [margin, margin, size - margin - 1, size - margin - 1],
+        radius=size // 5,
+        fill=(88, 86, 214, 255),
+    )
+    img.save(os.path.join(outdir, f'{size}x{size}.png'))
+img.save(os.path.join(outdir, 'icon.png'))
+print('Icons generated')
+"
+
+# ---------------------------------------------------------------------------
+# Step 6 — Build the React frontend
+# ---------------------------------------------------------------------------
+info "Building React frontend..."
+
+if [ ! -d "${WEB_DIR}/node_modules" ]; then
+    (cd "$WEB_DIR" && npm ci)
+fi
+
+(cd "$WEB_DIR" && VITE_API_BASE_URL="http://localhost:8080" npx vite build)
+
+# ---------------------------------------------------------------------------
+# Step 7 — Copy build artifacts into electron/resources/
+# ---------------------------------------------------------------------------
+info "Copying build artifacts into electron/resources/..."
+
+# Copy the embedded Python runtime.
+cp -a "${EMBEDDED_PYTHON}" "${RESOURCES_DIR}/python/"
+
+# Copy the compiled React frontend.
+cp -a "${WEB_DIR}/dist/"* "${RESOURCES_DIR}/web/"
+
+# ---------------------------------------------------------------------------
+# Step 8 — Build the Electron installer
+# ---------------------------------------------------------------------------
+info "Building Electron installer..."
+
+if [ ! -d "${ELECTRON_DIR}/node_modules" ]; then
+    (cd "$ELECTRON_DIR" && npm ci)
+fi
+
+(cd "$ELECTRON_DIR" && npm run build:linux)
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+info "Bundle build complete!"
+info "Installer artifacts are in ${ELECTRON_DIR}/dist/"
+ls -lh "${ELECTRON_DIR}/dist/"*.AppImage "${ELECTRON_DIR}/dist/"*.deb 2>/dev/null || \
+    warn "No installer artifacts found. Check the electron-builder output above."

--- a/package/pip.conf
+++ b/package/pip.conf
@@ -1,0 +1,2 @@
+[global]
+cache-dir = /home/appuser/.local/share/airunner/.cache/pip

--- a/packaging/windows/airunner.nsi
+++ b/packaging/windows/airunner.nsi
@@ -1,0 +1,87 @@
+!include "MUI2.nsh"
+
+!ifndef APP_NAME
+  !define APP_NAME "AIRunner"
+!endif
+
+!ifndef APP_VERSION
+  !define APP_VERSION "0.0.0"
+!endif
+
+!ifndef STAGING_DIR
+  !error "STAGING_DIR is required"
+!endif
+
+Name "${APP_NAME} ${APP_VERSION}"
+OutFile "airunner-${APP_VERSION}-windows-x64-setup.exe"
+InstallDir "$PROGRAMFILES64\AIRunner"
+InstallDirRegKey HKLM "Software\AIRunner" "Install_Dir"
+RequestExecutionLevel admin
+Unicode True
+
+!define MUI_ABORTWARNING
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "${STAGING_DIR}\LICENSE"
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "English"
+
+Section "Install"
+  SetOutPath "$INSTDIR"
+  File "${STAGING_DIR}\README.md"
+  File "${STAGING_DIR}\LICENSE"
+
+  SetOutPath "$INSTDIR\app"
+  File /r "${STAGING_DIR}\app\*"
+
+  SetOutPath "$INSTDIR\bin"
+  File /r "${STAGING_DIR}\bin\*"
+
+  SetOutPath "$INSTDIR\python"
+  File /r "${STAGING_DIR}\python\*"
+
+  SetOutPath "$INSTDIR\share"
+  File /r "${STAGING_DIR}\share\*"
+
+  IfFileExists "${STAGING_DIR}\deployment\*" 0 +3
+    SetOutPath "$INSTDIR\deployment"
+    File /r "${STAGING_DIR}\deployment\*"
+
+  WriteRegStr HKLM "Software\AIRunner" "Install_Dir" "$INSTDIR"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\AIRunner" "DisplayName" "AIRunner"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\AIRunner" "DisplayVersion" "${APP_VERSION}"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\AIRunner" "Publisher" "AIRunner"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\AIRunner" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\AIRunner" "NoModify" 1
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\AIRunner" "NoRepair" 1
+
+  CreateDirectory "$SMPROGRAMS\AIRunner"
+  CreateShortcut "$SMPROGRAMS\AIRunner\AIRunner.lnk" "$INSTDIR\bin\airunner.exe"
+  CreateShortcut "$SMPROGRAMS\AIRunner\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
+
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+SectionEnd
+
+Section "Uninstall"
+  Delete "$SMPROGRAMS\AIRunner\AIRunner.lnk"
+  Delete "$SMPROGRAMS\AIRunner\Uninstall.lnk"
+  RMDir "$SMPROGRAMS\AIRunner"
+
+  RMDir /r "$INSTDIR\app"
+  RMDir /r "$INSTDIR\bin"
+  RMDir /r "$INSTDIR\deployment"
+  RMDir /r "$INSTDIR\python"
+  RMDir /r "$INSTDIR\share"
+  Delete "$INSTDIR\README.md"
+  Delete "$INSTDIR\LICENSE"
+  Delete "$INSTDIR\Uninstall.exe"
+  RMDir "$INSTDIR"
+
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\AIRunner"
+  DeleteRegKey HKLM "Software\AIRunner"
+SectionEnd


### PR DESCRIPTION
Restores 4 files that were incorrectly deleted in PR #1992's cleanup:

- **package/build_bundle.sh** — referenced by README as the canonical Linux build command
- **package/build_bundle.ps1** — referenced by README as the canonical Windows build command
- **package/pip.conf** — used by the build scripts for pip configuration
- **packaging/windows/airunner.nsi** — Windows NSIS installer script

The other changes from PR #1992 (model_loader.py cleanup, test path fix, README removal, harness_project stubs) are all intentional and should stay.