### PR TITLE
fix: add dropped images to new layer instead of existing layer

### DIFF
--- a/client/src/features/canvas/useCanvasState.ts
+++ b/client/src/features/canvas/useCanvasState.ts
@@ -523,18 +523,16 @@ export function useCanvasState() {
           offsetY: 0,
           parentGroupId: null,
         };
-        const next = {
+        return recordSnapshot({
           ...prev,
           layers: [...prev.layers, newLayer],
+          displayOrder: [...prev.displayOrder, newLayerId],
           activeLayerId: newLayerId,
-        };
-        const { history, historyIndex } = pushHistory(
-          prev.history, prev.historyIndex, serialize(next),
-        );
-        return { ...next, history, historyIndex };
+          selectedLayerIds: [newLayerId],
+        });
       });
     },
-    [],
+    [recordSnapshot],
   );
 
   const placeImage = useCallback(


### PR DESCRIPTION
## Summary

When dragging an image onto the canvas (from the file system, image browser, or AI generation), images were being placed on a new layer via `placeImageOnNewLayer`, but the new layer was **invisible in the layers sidebar** because the function was not updating `displayOrder`.

### Changes

Fixed `placeImageOnNewLayer` in `useCanvasState.ts` to:
- Add the new layer to `displayOrder` — so it appears in the layers sidebar
- Set `selectedLayerIds` to the new layer — so it's visually selected
- Use `recordSnapshot` — for consistent history tracking

### Verification
- ✅ TypeScript compilation passes
- ✅ Pre-commit hooks pass
- ✅ All image drop paths already call `placeImageOnNewLayer`
- ✅ The layers sidebar now correctly shows the new layer