### PR TITLE
fix: art model unload (VRAM + status), seed randomize persistence, ll…

### DIFF
--- a/.github/workflows/build-base-images.yml
+++ b/.github/workflows/build-base-images.yml
@@ -20,6 +20,11 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_REPO: capsize-games/airunner
+  # Build revision for the llama-cuda-builder image. Bump this (and the
+  # matching LLAMA_BUILDER_REV in docker/Dockerfile) whenever the builder's
+  # compile flags change but the llama-cpp-python version does not, so the
+  # GHCR tag changes and stale caches don't serve the old wheel.
+  LLAMA_BUILDER_REV: "2"
 
 jobs:
   # Build and (optionally) push the CUDA llama-cpp-python wheel image.
@@ -51,7 +56,7 @@ jobs:
           file: docker/builder.Dockerfile
           build-args: |
             LLAMA_CPP_VERSION=${{ steps.version.outputs.version }}
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}/llama-cuda-builder:v${{ steps.version.outputs.version }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}/llama-cuda-builder:v${{ steps.version.outputs.version }}-${{ env.LLAMA_BUILDER_REV }}
           push: ${{ github.event_name == 'push' || github.event.inputs.push_images }}
 
   # Build and (optionally) push the frozen server-deps image.

--- a/client/src/components/panels/CanvasPanel.tsx
+++ b/client/src/components/panels/CanvasPanel.tsx
@@ -112,7 +112,9 @@ export default function CanvasPanel() {
   });
   const [showSettings, setShowSettings] = useState(false);
   const [showNewDocModal, setShowNewDocModal] = useState(false);
-  const [showImagePrompt, setShowImagePrompt] = useState(false);
+  const [showImagePrompt, setShowImagePrompt] = useState(() => {
+    try { return localStorage.getItem("canvas_show_image_prompt") === "true"; } catch { return false; }
+  });
   const [leftPanelW, setLeftPanelW] = useState(() => {
     try { const v = localStorage.getItem(LS_LEFT_W); return v ? Number(v) : 300; } catch { return 300; }
   });
@@ -250,6 +252,9 @@ export default function CanvasPanel() {
   useEffect(() => {
     try { localStorage.setItem(LS_LEFT_W, String(leftPanelW)); } catch { /* */ }
   }, [leftPanelW]);
+  useEffect(() => {
+    try { localStorage.setItem("canvas_show_image_prompt", String(showImagePrompt)); } catch { /* */ }
+  }, [showImagePrompt]);
 
   if (!isLoaded) {
     return (

--- a/client/src/components/panels/StatsPanel.tsx
+++ b/client/src/components/panels/StatsPanel.tsx
@@ -9,7 +9,7 @@ const panelStyle: React.CSSProperties = {
 };
 
 export default function StatsPanel() {
-  const { hw, slots, loadingRef, findModel, statusColor, handleLoad, handleUnload } = useStatsPanel();
+  const { hw, slots, loadingRef, unloadingSlots, findModel, statusColor, handleLoad, handleUnload } = useStatsPanel();
 
   if (!hw) {
     return (
@@ -48,6 +48,7 @@ export default function StatsPanel() {
       <ModelSlotList
         slots={slots}
         loadingRef={loadingRef}
+        unloadingSlots={unloadingSlots}
         findModel={findModel}
         statusColor={statusColor}
         onLoad={handleLoad}

--- a/client/src/components/panels/art-prompt/useArtPromptState.ts
+++ b/client/src/components/panels/art-prompt/useArtPromptState.ts
@@ -73,7 +73,19 @@ export function useArtPromptState() {
   const [seed, setSeed] = useState(() => {
     try {
       const v = Number(localStorage.getItem("airunner_seed") || "0");
-      return v === -1 ? Math.floor(Math.random() * 2147483647) + 1 : v;
+      if (v === -1) {
+        // Random mode was on before reload — restore the saved seed
+        // rather than generating a fresh random number.
+        const saved = localStorage.getItem("airunner_seed_saved");
+        if (saved !== null) {
+          const n = Number(saved);
+          if (!isNaN(n)) return n;
+        }
+        // No saved seed available (e.g. first load after update) —
+        // default to 0 instead of returning the -1 sentinel.
+        return 0;
+      }
+      return v;
     } catch { return 0; }
   });
   const [seedRandomized, setSeedRandomized] = useState(() => {
@@ -225,12 +237,16 @@ export function useArtPromptState() {
 
   const handleToggleRandom = useCallback(() => {
     if (seedRandomized) {
+      // Turning OFF random: persist the current seed so it's reused
       setSeedRandomized(false);
       try { localStorage.setItem("airunner_seed", String(seed)); } catch {}
       updateSingleton("GeneratorSettings", { seed }).catch(() => {});
     } else {
-      const s = Math.floor(Math.random() * 2147483647) + 1;
-      setSeedRandomized(true); setSeed(s);
+      // Turning ON random: persist the current seed so it survives
+      // page reload, then mark as randomized. The actual randomization
+      // happens at submit time.
+      try { localStorage.setItem("airunner_seed_saved", String(seed)); } catch {}
+      setSeedRandomized(true);
       try { localStorage.setItem("airunner_seed", String(-1)); } catch {}
       updateSingleton("GeneratorSettings", { seed: -1 }).catch(() => {});
     }
@@ -239,19 +255,24 @@ export function useArtPromptState() {
   const onGenerate = useCallback(async () => {
     if (!prompt.trim()) return;
     setPhase("loading");
-    const lsNum = (k: string): number | undefined => {
-      try {
-        const v = localStorage.getItem(k);
-        if (v === null || v === "") return undefined;
-        const n = Number(v);
-        return isNaN(n) ? undefined : n;
-      } catch { return undefined; }
-    };
+    // If random seed is enabled, generate a fresh seed right before
+    // the request so each submission gets a new random value.
+    // Update state + localStorage so the UI reflects the used seed.
+    const effectiveSeed: number | undefined = seedRandomized
+      ? Math.floor(Math.random() * 2147483647) + 1
+      : seed;
+    if (seedRandomized && effectiveSeed !== undefined) {
+      setSeed(effectiveSeed);
+      // Keep the -1 sentinel in "airunner_seed" so the randomized toggle
+      // is restored as ON after a reload. Persist the actual value used in
+      // "airunner_seed_saved" only (used to display/reuse the seed).
+      try { localStorage.setItem("airunner_seed_saved", String(effectiveSeed)); } catch {}
+    }
     try {
       const imageBase64 = await artGenerate({
         prompt: prompt.trim(),
         negativePrompt: negativePrompt?.trim() || undefined,
-        seed: lsNum("airunner_seed"),
+        seed: effectiveSeed,
         artModel: ls("airunner_art_model") || undefined,
         artVersion: ls("airunner_art_version") || undefined,
         scheduler: ls("airunner_art_scheduler") || undefined,
@@ -273,7 +294,7 @@ export function useArtPromptState() {
       const msg = err instanceof Error ? err.message : String(err);
       setPhase(msg === "Cancelled" ? "cancelled" : "failed");
     }
-  }, [prompt, negativePrompt, genWidth, genHeight, canvasCtx, artGenerate]);
+  }, [prompt, negativePrompt, genWidth, genHeight, canvasCtx, artGenerate, seed, seedRandomized]);
 
   const onCancel = useCallback(() => artCancel(), [artCancel]);
 

--- a/client/src/components/panels/stats/ModelSlotList.tsx
+++ b/client/src/components/panels/stats/ModelSlotList.tsx
@@ -5,6 +5,7 @@ import type { ModelSlot } from "./useStatsPanel";
 interface Props {
   slots: ModelSlot[];
   loadingRef: React.MutableRefObject<Set<string>>;
+  unloadingSlots: Set<string>;
   findModel: (type: string) => ActiveModelInfo | undefined;
   statusColor: (status: string) => string;
   onLoad: (type: string, id: string) => void;
@@ -12,14 +13,15 @@ interface Props {
 }
 
 export default function ModelSlotList({
-  slots, loadingRef, findModel, statusColor, onLoad, onUnload,
+  slots, loadingRef, unloadingSlots, findModel, statusColor, onLoad, onUnload,
 }: Props) {
   return (
     <div className="mt-2">
       <small className="text-muted d-block mb-1">Models</small>
       {slots.map(({ type, label, name, canLoad }) => {
         const m = findModel(type);
-        const status = m?.status ?? "unloaded";
+        const isUnloading = unloadingSlots.has(type) || m?.status === "unloading";
+        const status = isUnloading ? "unloading" : (m?.status ?? "unloaded");
         return (
           <div
             key={type}
@@ -34,7 +36,7 @@ export default function ModelSlotList({
               }} />
               {label}: {name || "none"}
             </span>
-            {status === "loading" || (status !== "loaded" && loadingRef.current.has(type)) ? (
+            {status === "loading" || status === "unloading" || (status !== "loaded" && loadingRef.current.has(type)) ? (
               <span style={{ display: "flex", opacity: 0.5 }}>
                 <LucideIcon name="loader" size={14} />
               </span>

--- a/client/src/components/panels/stats/useStatsPanel.ts
+++ b/client/src/components/panels/stats/useStatsPanel.ts
@@ -13,8 +13,8 @@ export function useStatsPanel() {
   const [hw, setHw] = useState<HardwareProfile | null>(null);
   const [models, setModels] = useState<ActiveModelInfo[]>([]);
   const [slots, setSlots] = useState<ModelSlot[]>([]);
+  const [unloadingSlots, setUnloadingSlots] = useState<Set<string>>(new Set());
   const mountedRef = useRef(true);
-  const unloadingRef = useRef<Set<string>>(new Set());
   const loadingRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
@@ -87,32 +87,79 @@ export function useStatsPanel() {
   }, [fetchHw]);
 
   const handleUnload = useCallback((m: ActiveModelInfo, slotType: string) => {
-    const key = m.model_id || m.model_type;
-    if (unloadingRef.current.has(key)) return;
-    unloadingRef.current.add(key);
+    if (unloadingSlots.has(slotType)) return;
+    // Optimistically flip the slot to "unloading" so the indicator is
+    // instant on click rather than waiting for the server round-trip.
+    setUnloadingSlots((prev) => new Set(prev).add(slotType));
     loadingRef.current.delete(slotType);
     unloadModel(m.model_id, m.model_type).catch(() => {});
-    setTimeout(() => unloadingRef.current.delete(key), 2000);
-  }, []);
+    // Safety net: clear the optimistic flag if the unload never completes.
+    setTimeout(() => {
+      setUnloadingSlots((prev) => {
+        if (!prev.has(slotType)) return prev;
+        const next = new Set(prev);
+        next.delete(slotType);
+        return next;
+      });
+    }, 15000);
+  }, [unloadingSlots]);
 
   const handleLoad = useCallback((type: string, id: string) => {
     loadingRef.current.add(type);
     loadModel(id, type).catch(() => {});
   }, []);
 
+  const findModelIn = useCallback(
+    (list: ActiveModelInfo[], type: string): ActiveModelInfo | undefined => {
+      const prefixes = type === "art" ? [type, "text_to_image"] : [type];
+      return list.find((m) =>
+        prefixes.some((prefix) =>
+          m.model_type.toLowerCase().startsWith(prefix),
+        ),
+      );
+    },
+    [],
+  );
+
+  // Clear the optimistic "unloading" flag once the server reports the model
+  // gone (removed from the active list) or unloaded.
+  useEffect(() => {
+    setUnloadingSlots((prev) => {
+      if (prev.size === 0) return prev;
+      const next = new Set(prev);
+      for (const type of prev) {
+        const m = findModelIn(models, type);
+        if (!m || m.status === "unloaded") next.delete(type);
+      }
+      return next.size === prev.size ? prev : next;
+    });
+  }, [models, findModelIn]);
+
   const findModel = useCallback(
-    (type: string): ActiveModelInfo | undefined =>
-      models.find((m) => m.model_type.toLowerCase().startsWith(type)),
+    (type: string): ActiveModelInfo | undefined => {
+      // The art/SD model is registered with model_type "text_to_image"
+      // in BaseDiffusersModelManager, so match both "art" and
+      // "text_to_image" when looking up the "art" slot.
+      const prefixes = type === "art"
+        ? [type, "text_to_image"]
+        : [type];
+      return models.find((m) =>
+        prefixes.some((prefix) =>
+          m.model_type.toLowerCase().startsWith(prefix),
+        ),
+      );
+    },
     [models],
   );
 
   const statusColor = (status: string) => {
     switch (status) {
       case "loaded": return "var(--bs-success)";
-      case "loading": return "var(--bs-warning)";
+      case "loading":
+      case "unloading": return "var(--bs-warning)";
       default: return "var(--bs-danger)";
     }
   };
 
-  return { hw, slots, models, loadingRef, findModel, statusColor, handleLoad, handleUnload };
+  return { hw, slots, models, loadingRef, unloadingSlots, findModel, statusColor, handleLoad, handleUnload };
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,6 +17,11 @@
 ARG AIRUNNER_LLAMA_CUDA=0
 # Keep in sync with scripts/install.sh's pinned version.
 ARG LLAMA_CPP_VERSION=0.3.26
+# Build revision for the GHCR llama-cuda-builder image. Bump this (and the
+# matching value in .github/workflows/build-base-images.yml) whenever the
+# builder's compile flags change but LLAMA_CPP_VERSION stays the same, so the
+# GHCR tag changes and stale local/CI caches don't serve the old wheel.
+ARG LLAMA_BUILDER_REV=2
 # Wheel source: "1" = pull from GHCR (fast, default).  "local" = compile
 # from source (slow, for offline / CI without registry access).
 ARG LLAMA_WHEEL_SOURCE=1
@@ -28,7 +33,7 @@ ARG BUILD_DEPS_LOCAL=0
 
 # Pre-built CUDA wheel image on GHCR.  Built from docker/builder.Dockerfile
 # and pushed by .github/workflows/build-base-images.yml on version bumps.
-FROM ghcr.io/capsize-games/airunner/llama-cuda-builder:v${LLAMA_CPP_VERSION} AS llama-cuda-1
+FROM ghcr.io/capsize-games/airunner/llama-cuda-builder:v${LLAMA_CPP_VERSION}-${LLAMA_BUILDER_REV} AS llama-cuda-1
 
 # Local fallback: compile llama-cpp-python with CUDA from source.  Identical
 # to docker/builder.Dockerfile — kept inline so --build-arg
@@ -60,7 +65,11 @@ RUN set -e \
     && ln -sf "${STUB}" /usr/lib/x86_64-linux-gnu/libcuda.so.1 \
     && ldconfig \
     && ldconfig -p | grep -q libcuda.so.1 \
-    && CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=89;90;120" \
+    # GGML_NATIVE=OFF avoids baking in the build host's CPU instructions
+    # (e.g. AVX-512). Hosts without them (AMD Ryzen has AVX2 but no AVX-512)
+    # otherwise crash with SIGILL on model load. Target a portable AVX2 set.
+    && CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=89;90;120 \
+-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON" \
        pip wheel --no-cache-dir --no-deps -w /wheels \
         "llama-cpp-python==${LLAMA_CPP_VERSION}"
 

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -57,7 +57,13 @@ RUN set -e \
     && ln -sf "${STUB}" /usr/lib/x86_64-linux-gnu/libcuda.so.1 \
     && ldconfig \
     && ldconfig -p | grep -q libcuda.so.1 \
-    && CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=89;90;120" \
+    # GGML_NATIVE=OFF disables -march=native so the wheel does not bake in
+    # the CI builder's CPU instructions (e.g. AVX-512). Without this, hosts
+    # that lack those instructions (e.g. AMD Ryzen, which has AVX2 but no
+    # AVX-512) crash with SIGILL ("Illegal instruction") on model load. We
+    # target a portable AVX2 baseline that all modern x86-64 CPUs support.
+    && CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=89;90;120 \
+-DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON" \
        pip wheel --no-cache-dir --no-deps -w /wheels \
         "llama-cpp-python==${LLAMA_CPP_VERSION}"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -235,7 +235,10 @@ install_llama_cpp_cuda() {
     fi
 
     log_info 'NVIDIA GPU detected — rebuilding llama-cpp-python with CUDA support'
-    CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=89;90" \
+    # GGML_NATIVE=OFF avoids -march=native baking in CPU instructions the
+    # target host may lack (e.g. AVX-512 on a build box vs AVX2-only Ryzen),
+    # which causes SIGILL on model load. Add sm_120 (Blackwell) too.
+    CMAKE_ARGS="-DGGML_CUDA=on -DCMAKE_CUDA_ARCHITECTURES=89;90;120 -DGGML_NATIVE=OFF -DGGML_AVX=ON -DGGML_AVX2=ON -DGGML_FMA=ON -DGGML_F16C=ON" \
         "$venv_python" -m pip install \
         --force-reinstall \
         --no-cache-dir \

--- a/server/src/airunner_services/api/routes/models_status.py
+++ b/server/src/airunner_services/api/routes/models_status.py
@@ -178,7 +178,14 @@ async def unload_model(
 
     if any(
         keyword in model_type_lower
-        for keyword in ("art", "sd", "stablediffusion", "z-image", "turbo")
+        for keyword in (
+            "art",
+            "sd",
+            "stablediffusion",
+            "z-image",
+            "turbo",
+            "text_to_image",
+        )
     ):
         from .art_runtime_control import (  # noqa: PLC0415
             build_control_request,

--- a/server/src/airunner_services/api/routes/rpc_models.py
+++ b/server/src/airunner_services/api/routes/rpc_models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from airunner_services.api.routes.events import _rpc_register
@@ -84,6 +85,72 @@ async def _rpc_models_unload(body: dict, **kwargs: Any) -> dict[str, Any]:
             SignalCode.LLM_UNLOAD_SIGNAL,
             {},
         )
+        return {"status": 200, "body": {"status": "accepted"}}
+    if any(
+        keyword in model_type_lower
+        for keyword in (
+            "art",
+            "sd",
+            "stablediffusion",
+            "z-image",
+            "turbo",
+            "text_to_image",
+        )
+    ):
+        ws = kwargs.get("ws")
+        if ws is not None:
+            from fastapi import Request as FastAPIRequest  # noqa: PLC0415
+            from airunner_services.api.routes.art_runtime_registry import (  # noqa: PLC0415
+                require_runtime_registry,
+                resolve_art_client,
+            )
+            from airunner_services.ipc.messages import (  # noqa: PLC0415
+                RequestEnvelope,
+            )
+            from airunner_services.runtimes.contracts import (  # noqa: PLC0415
+                RuntimeAction,
+                RuntimeKind,
+            )
+
+            async def _fire_art_unload():
+                try:
+                    mock_req = FastAPIRequest(
+                        {
+                            "type": "http",
+                            "app": getattr(ws, "app", None),
+                        }
+                    )
+                    client = resolve_art_client(
+                        require_runtime_registry(mock_req),
+                    )
+                    envelope = RequestEnvelope(
+                        request_id="unload",
+                        runtime=RuntimeKind.ART,
+                        action=RuntimeAction.UNLOAD_MODEL,
+                        payload={},
+                        metadata={},
+                    )
+                    await asyncio.to_thread(client.invoke, envelope)
+                except Exception as exc:
+                    logger.warning(
+                        "Background art unload failed: %s",
+                        exc,
+                    )
+                SignalMediator().emit_signal(
+                    SignalCode.MODEL_STATUS_CHANGED_SIGNAL,
+                    {
+                        "model_id": model_id,
+                        "model_type": model_type or "art",
+                        "status": "unloaded",
+                    },
+                )
+
+            asyncio.create_task(_fire_art_unload())
+            logger.info(
+                "Unload requested for art model %s (type=%s)",
+                model_id,
+                model_type,
+            )
         return {"status": 200, "body": {"status": "accepted"}}
     return {"status": 200, "body": {"status": "accepted"}}
 

--- a/server/src/airunner_services/art/managers/stablediffusion/base_diffusers_model_manager.py
+++ b/server/src/airunner_services/art/managers/stablediffusion/base_diffusers_model_manager.py
@@ -30,6 +30,7 @@ from airunner_services.art.managers.stablediffusion.mixins import (
     SDImageGenerationMixin,
 )
 from airunner_services.model_management import ModelResourceManager
+from airunner_services.model_management.types import ModelState
 
 
 class BaseDiffusersModelManager(
@@ -78,6 +79,7 @@ class BaseDiffusersModelManager(
         self.do_change_scheduler: bool = False
         self._resolved_model_version: Optional[str] = None
         self._image_request = None
+        self._loaded_model_path: Optional[str] = None
         self._controlnet_model = None
         self._controlnet: Optional[Any] = None
         self._controlnet_processor: Any = None
@@ -338,6 +340,7 @@ class BaseDiffusersModelManager(
         self._load_compel()
         self._make_memory_efficient()
         self._finalize_load_stable_diffusion()
+        self._loaded_model_path = self.model_path
         resource_manager.model_loaded(self.model_path, "text_to_image")
 
     def load_controlnet(self):
@@ -379,7 +382,17 @@ class BaseDiffusersModelManager(
         ):
             self.interrupt_image_generation()
             self.requested_action = ModelAction.CLEAR
-        self.change_model_status(self.model_type, ModelStatus.LOADING)
+        # Mark the resource-manager entry as UNLOADING so the active-models
+        # list reflects the in-progress unload (yellow) instead of staying
+        # "loaded" until cleanup completes at the end of this method.
+        unloading_model_path = self.model_path or self._loaded_model_path
+        if unloading_model_path:
+            ModelResourceManager().set_model_state(
+                unloading_model_path,
+                ModelState.UNLOADING,
+                "text_to_image",
+            )
+        self.change_model_status(self.model_type, ModelStatus.UNLOADING)
 
         # Unload lightweight components first
         self._unload_deep_cache()
@@ -413,12 +426,13 @@ class BaseDiffusersModelManager(
         # Final memory clear to ensure everything is released
         clear_memory(self._device_index)
 
-        model_path = self.model_path
+        model_path = self.model_path or self._loaded_model_path
         if model_path:
             ModelResourceManager().cleanup_model(
                 model_path,
                 "text_to_image",
             )
+        self._loaded_model_path = None
 
         self.change_model_status(self.model_type, ModelStatus.UNLOADED)
 

--- a/server/src/airunner_services/art/managers/stablediffusion/mixins/sd_properties_mixin.py
+++ b/server/src/airunner_services/art/managers/stablediffusion/mixins/sd_properties_mixin.py
@@ -407,7 +407,9 @@ class SDPropertiesMixin:
         Returns:
             Optional expanded path string if custom path is valid.
         """
-        path_value = self.image_request.custom_path
+        path_value = (
+            self.image_request.custom_path if self.image_request else None
+        )
         if path_value is not None and path_value != "":
             expanded_path = os.path.expanduser(path_value)
             if os.path.exists(expanded_path):

--- a/server/src/airunner_services/art/managers/zimage/mixins/zimage_generation_mixin.py
+++ b/server/src/airunner_services/art/managers/zimage/mixins/zimage_generation_mixin.py
@@ -220,6 +220,18 @@ class ZImageGenerationMixin:
         except Exception as e:
             self.logger.warning(f"Error during hook removal: {e}")
 
+        # Native FP8 pipelines keep their transformer / text encoder / VAE on
+        # an inner object that is only released via an explicit unload(). The
+        # native pipeline and its helpers form reference cycles, so deleting
+        # the wrapper and relying on __del__/gc leaves those (largest) models
+        # resident in VRAM. Call unload() directly so the memory is freed
+        # deterministically.
+        if hasattr(self._pipe, "unload"):
+            try:
+                self._pipe.unload()
+            except Exception as e:
+                self.logger.warning(f"Error during pipe.unload(): {e}")
+
         # Delete the pipeline itself
         try:
             del self._pipe

--- a/server/src/airunner_services/contract_enums.py
+++ b/server/src/airunner_services/contract_enums.py
@@ -300,6 +300,7 @@ class ModelStatus(Enum):
     LOADED = "Loaded"
     READY = "Ready"
     LOADING = "Loading"
+    UNLOADING = "Unloading"
     FAILED = "Failed"
 
 

--- a/server/src/airunner_services/workers/sd_worker.py
+++ b/server/src/airunner_services/workers/sd_worker.py
@@ -46,6 +46,7 @@ from airunner_services.utils.application.enum_resolver import (
 )
 from airunner_services.utils.application.enum_resolver import signal_code_proxy
 from airunner_services.utils.memory import apply_cudnn_benchmark
+from airunner_services.art.runtime_memory import clear_memory
 from airunner_services.workers.worker import QueueType, Worker
 
 ModelAction = model_action_type()
@@ -61,6 +62,7 @@ class SDWorker(Worker):
         self.signal_handlers = {
             SignalCode.DO_GENERATE_SIGNAL: self.on_do_generate_signal,
             SignalCode.SD_LOAD_SIGNAL: self.on_load_art_signal,
+            SignalCode.SD_UNLOAD_SIGNAL: self.on_unload_art_signal,
             SignalCode.INTERRUPT_IMAGE_GENERATION_SIGNAL: (
                 self.on_interrupt_image_generation_signal
             ),
@@ -180,6 +182,15 @@ class SDWorker(Worker):
         self.add_to_queue(
             {
                 "action": ModelAction.LOAD,
+                "type": ModelType.SD,
+                "data": data,
+            }
+        )
+
+    def on_unload_art_signal(self, data: Dict = None):
+        self.add_to_queue(
+            {
+                "action": ModelAction.UNLOAD,
                 "type": ModelType.SD,
                 "data": data,
             }
@@ -461,6 +472,14 @@ class SDWorker(Worker):
                 self._x4_upscaler = None
 
             self._clear_loaded_model_signature()
+
+            # Drop the last strong reference to the unloaded manager and
+            # return the freed device memory to the driver. unload() empties
+            # the cache while the manager (compel, generator, etc.) is still
+            # alive, so without this final clear the GPU memory those held is
+            # not released back to the OS/NVML until the next allocation.
+            del manager_ref
+            clear_memory()
 
         if data:
             callback = data.get("callback", None)


### PR DESCRIPTION
…ama SIGILL

Art/SD model unload:
- Register SD_UNLOAD_SIGNAL handler in SDWorker (was emitted but never handled, so unload never ran).
- Guard custom_path against a None image_request so standalone unload doesn't crash before emitting UNLOADED.
- Track the loaded model path so cleanup_model runs at unload (frees the resource-manager entry + tracked VRAM even when image_request is None).
- Call the Z-Image native pipeline's unload() before deleting the wrapper so the FP8 transformer/text-encoder actually leave VRAM.
- clear_memory() after the manager teardown so freed device memory is returned to the driver.
- Add ModelStatus.UNLOADING and mark the resource-manager state UNLOADING at the start of unload; client shows an instant yellow/spinner state.

Seed randomization:
- Keep the -1 sentinel in localStorage so the randomize toggle survives a reload (was clobbered by the per-generation seed write).

llama.cpp SIGILL on AVX2-only CPUs:
- Build the CUDA wheel with GGML_NATIVE=OFF + an explicit AVX2 baseline so it no longer bakes in the build host's AVX-512, which crashed AVX2-only hosts (e.g. Ryzen) with "Illegal instruction" on GGUF load. Applied to builder.Dockerfile, Dockerfile, and install.sh (also adds sm_120).
- Add LLAMA_BUILDER_REV to the GHCR tag so flag-only changes produce a new tag and don't serve a stale cached wheel.