### PR TITLE
Support a remote OpenAI-compatible llama.cpp endpoint

### DIFF
--- a/src/airunner/runtimes/llama_cpp_runtime_settings.py
+++ b/src/airunner/runtimes/llama_cpp_runtime_settings.py
@@ -42,6 +42,12 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+def _env_optional_str(name: str) -> Optional[str]:
+    """Return a stripped environment value, or None when unset/blank."""
+    value = os.environ.get(name, "").strip()
+    return value or None
+
+
 def _load_llm_settings() -> Any:
     """Return persisted LLM settings when the database is available."""
     try:
@@ -179,10 +185,13 @@ class LlamaCppRuntimeSettings:
     n_ctx: int
     n_gpu_layers: int
     startup_timeout_seconds: float
+    remote_base_url: Optional[str] = None
 
     @property
     def endpoint(self) -> str:
-        """Return the HTTP endpoint exposed by the sidecar."""
+        """Return the HTTP endpoint for the sidecar or a configured remote server."""
+        if self.remote_base_url:
+            return self.remote_base_url.rstrip("/")
         return f"http://{self.host}:{self.port}"
 
 
@@ -216,4 +225,5 @@ def resolve_llama_cpp_runtime_settings() -> LlamaCppRuntimeSettings:
             "AIRUNNER_LLAMA_STARTUP_TIMEOUT",
             DEFAULT_STARTUP_TIMEOUT_SECONDS,
         ),
+        remote_base_url=_env_optional_str("AIRUNNER_LLAMA_REMOTE_BASE_URL"),
     )

--- a/src/airunner/runtimes/sidecar_launcher.py
+++ b/src/airunner/runtimes/sidecar_launcher.py
@@ -47,6 +47,11 @@ class SidecarLauncher:
         return self.settings.endpoint
 
     @property
+    def is_remote(self) -> bool:
+        """Return True when a remote llama.cpp endpoint is configured."""
+        return bool(self.settings.remote_base_url)
+
+    @property
     def last_error(self) -> str:
         """Return the last launcher error message when one exists."""
         return self._last_error
@@ -69,15 +74,20 @@ class SidecarLauncher:
         ]
 
     def start(self) -> None:
-        """Start the sidecar and wait until its health endpoint responds."""
+        """Start the sidecar, or confirm a configured remote server is up."""
         if self.is_ready():
             return
         self._last_error = ""
+        if self.is_remote:
+            self._wait_until_remote_ready()
+            return
         self._spawn_if_needed()
         self._wait_until_ready()
 
     def stop(self) -> None:
         """Stop the managed process when one is running."""
+        if self.is_remote:
+            return
         process = self._process
         self._process = None
         try:
@@ -93,7 +103,9 @@ class SidecarLauncher:
             self._close_log_handle()
 
     def is_running(self) -> bool:
-        """Return True when the subprocess is still alive."""
+        """Return True when the subprocess is alive, or always for a remote server."""
+        if self.is_remote:
+            return True
         return self._process is not None and self._process.poll() is None
 
     def is_ready(self) -> bool:
@@ -110,6 +122,12 @@ class SidecarLauncher:
         """Return the runtime health state exposed to AIRunner."""
         if self.is_ready():
             return RuntimeHealthStatus.READY, "ready"
+        if self.is_remote:
+            message = (
+                self._last_error
+                or f"Remote endpoint {self.endpoint} is not reachable"
+            )
+            return RuntimeHealthStatus.FAILED, message
         if self.is_running():
             return RuntimeHealthStatus.STARTING, "starting"
         if self._process is not None and self._process.poll() is not None:
@@ -166,6 +184,20 @@ class SidecarLauncher:
 
         self.stop()
         self._last_error = "Timed out waiting for llama.cpp to become ready"
+        raise RuntimeError(self._last_error)
+
+    def _wait_until_remote_ready(self) -> None:
+        """Poll a configured remote endpoint until it responds or times out."""
+        deadline = self._time_fn() + self.settings.startup_timeout_seconds
+        while self._time_fn() < deadline:
+            if self.is_ready():
+                return
+            self._sleep(0.1)
+
+        self._last_error = (
+            f"Timed out waiting for remote endpoint {self.endpoint} "
+            "to become ready"
+        )
         raise RuntimeError(self._last_error)
 
     def _health_url(self) -> str:

--- a/src/airunner/runtimes/sidecar_llm_client.py
+++ b/src/airunner/runtimes/sidecar_llm_client.py
@@ -179,7 +179,10 @@ class SidecarLLMClient(RuntimeClient):
     ) -> dict[str, Any]:
         """Convert a neutral invocation into the sidecar JSON payload."""
         payload = {
-            "messages": [message.model_dump() for message in invocation.messages],
+            "messages": [
+                message.model_dump(exclude_none=True)
+                for message in invocation.messages
+            ],
             "stream": stream,
             "temperature": invocation.temperature,
         }

--- a/src/airunner/runtimes/tests/test_sidecar_llm_client.py
+++ b/src/airunner/runtimes/tests/test_sidecar_llm_client.py
@@ -138,6 +138,7 @@ def test_invoke_wraps_chat_completion_response():
 
     assert launcher.started == 1
     assert opened[0]["messages"][0]["content"] == "Say hello"
+    assert "name" not in opened[0]["messages"][0]
     assert response.payload["content"] == "hello"
     assert response.payload["usage"]["total_tokens"] == 7
 


### PR DESCRIPTION
## Summary
- Adds `AIRUNNER_LLAMA_REMOTE_BASE_URL` so the local LLM backend can point at an already-running, remote OpenAI-compatible llama.cpp server (e.g. `llama-swap`) instead of always spawning and owning its own subprocess.
- `SidecarLauncher` skips process spawning and instead polls the remote `/health` endpoint when a remote base URL is configured; local-mode behavior (spawn-and-own a local `llama-server`) is unchanged when the env var is unset.
- Fixes `_chat_payload` sending a literal `"name": null` in chat messages, which real llama.cpp servers reject with a JSON parse error — found while verifying a real completion against a remote endpoint. Applies to both local and remote sidecar modes.

## Test plan
- [x] `pytest src/airunner/runtimes/tests/` — 84 passed (1 pre-existing, unrelated failure: missing `soundfile` for a TTS test, not touched by this change)
- [x] Verified a real non-streaming completion against a remote llama.cpp-compatible server via `AIRUNNER_LLAMA_REMOTE_BASE_URL`
- [x] Verified a real streaming completion (SSE) through the fully-managed `SidecarLLMClient()` constructor (the path the app actually uses) against the same remote server
- [x] Confirmed local-mode default behavior (`remote_base_url=None`, endpoint reverts to `127.0.0.1:<port>`) is unchanged
- [x] `airunner` launches and stays running without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)