### PR TITLE
fix(legal, pkg): GPL-3.0 license consistency + services build isolation (#2058, #2064)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AI Runner is a private AI companion you shape — name, personality, voice, memo
 <img src="./images/art_interface.png" alt="AI Runner Logo" />
 
 
-[![PyPi](https://github.com/Capsize-Games/airunner/actions/workflows/pypi-dispatch.yml/badge.svg)](https://github.com/Capsize-Games/airunner/actions/workflows/pypi-dispatch.yml) ![GitHub last commit](https://img.shields.io/github/last-commit/Capsize-Games/airunner)
+[![PyPi](https://github.com/Capsize-Games/airunner/actions/workflows/pypi-dispatch.yml/badge.svg)](https://github.com/Capsize-Games/airunner/actions/workflows/pypi-dispatch.yml) ![GitHub last commit](https://img.shields.io/github/last-commit/Capsize-Games/airunner) [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 [🐞 Report Bug](https://github.com/Capsize-Games/airunner/issues/new?template=bug_report.md) · [✨ Request Feature](https://github.com/Capsize-Games/airunner/issues/new?template=feature_request.md) · [🛡️ Report Vulnerability](https://github.com/Capsize-Games/airunner/issues/new?template=vulnerability_report.md) · [📖 Wiki](https://github.com/Capsize-Games/airunner/wiki)
 

--- a/native/setup.py
+++ b/native/setup.py
@@ -13,6 +13,13 @@ from setuptools import find_packages, setup
 
 VERSION = "6.0.0"
 
+# The project is GPL-3.0-only (issue #2058): the repo-root LICENSE file, every
+# ``license=`` metadata field and these PyPI classifiers must agree. Mirrored
+# from shared/airunner_common/package_metadata.py (LICENSE_CLASSIFIERS).
+LICENSE_CLASSIFIERS = [
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+]
+
 # Supply-chain hardening (issue #2036): the archive URL is hash-pinned so a
 # tampered or moved tag cannot be substituted. Digest computed from the
 # current v1.0.0 tarball (curl -sL <url> | sha256sum).
@@ -79,6 +86,7 @@ def build_native_setup_kwargs(*, package_source_dir: str) -> dict[str, object]:
         "long_description": README,
         "long_description_content_type": "text/markdown",
         "license": "GPL-3.0-only",
+        "classifiers": LICENSE_CLASSIFIERS,
         "author_email": "contact@capsizegames.com",
         "url": "https://github.com/Capsize-Games/airunner",
         "package_dir": {"": package_source_dir},

--- a/services/setup.py
+++ b/services/setup.py
@@ -13,6 +13,13 @@ from setuptools import find_packages, setup
 
 VERSION = "6.0.0"
 
+# The project is GPL-3.0-only (issue #2058): the repo-root LICENSE file, every
+# ``license=`` metadata field and these PyPI classifiers must agree. Mirrored
+# from shared/airunner_common/package_metadata.py (LICENSE_CLASSIFIERS).
+LICENSE_CLASSIFIERS = [
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+]
+
 # Supply-chain hardening (issue #2036): the archive URL is hash-pinned so a
 # tampered or moved tag cannot be substituted. Digest computed from the
 # current v1.0.0 tarball (curl -sL <url> | sha256sum).
@@ -374,6 +381,7 @@ def build_services_setup_kwargs(*, package_source_dir: str) -> dict[str, object]
         "long_description": README,
         "long_description_content_type": "text/markdown",
         "license": "GPL-3.0-only",
+        "classifiers": LICENSE_CLASSIFIERS,
         "author_email": "contact@capsizegames.com",
         "url": "https://github.com/Capsize-Games/airunner",
         "package_dir": {"": package_source_dir},

--- a/services/tests/test_build_isolation.py
+++ b/services/tests/test_build_isolation.py
@@ -1,0 +1,55 @@
+"""Build-system isolation guard for the services package (issue #2064).
+
+``pip wheel services/`` runs in an isolated PEP 517 build environment that only
+contains the ``[build-system] requires`` entries. services/setup.py must
+therefore never import the shared ``airunner_common`` package (or anything else
+not declared there) at setup time, or the build fails with
+ModuleNotFoundError. These tests lock that invariant in place.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _imports_setuptools_only(path: Path) -> list[str]:
+    """Return the module-level imports (or import-from) of a setup.py file."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    imported: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imported.append(node.module)
+    return imported
+
+
+def test_services_setup_py_has_no_module_level_airunner_common_import() -> None:
+    """The build metadata is vendored; no shared-package import at setup time."""
+    imports = _imports_setuptools_only(_PROJECT_ROOT / "services" / "setup.py")
+    assert not any(
+        imp == "airunner_common" or imp.startswith("airunner_common.")
+        for imp in imports
+    ), f"services/setup.py must not import airunner_common at build time, got: {imports}"
+
+
+def test_native_setup_py_has_no_module_level_airunner_common_import() -> None:
+    """native/setup.py follows the same self-contained rule (issue #2038)."""
+    imports = _imports_setuptools_only(_PROJECT_ROOT / "native" / "setup.py")
+    assert not any(
+        imp == "airunner_common" or imp.startswith("airunner_common.")
+        for imp in imports
+    ), f"native/setup.py must not import airunner_common at build time, got: {imports}"
+
+
+def test_services_pyproject_declares_build_backend() -> None:
+    """services/pyproject.toml must declare a PEP 517 build backend."""
+    text = (_PROJECT_ROOT / "services" / "pyproject.toml").read_text(
+        encoding="utf-8"
+    )
+    assert "[build-system]" in text
+    assert "build-backend = \"setuptools.build_meta\"" in text
+    assert "setuptools" in text, "setuptools must be in build-system requires"

--- a/services/tests/test_license_consistency.py
+++ b/services/tests/test_license_consistency.py
@@ -1,0 +1,139 @@
+"""License consistency guard for the AIRunner package surfaces (issue #2058).
+
+The project is GPL-3.0-only. The repo-root LICENSE, every ``license=``
+metadata field, the PyPI license classifiers and the README license badge must
+agree, or downstream users/redistributors cannot determine their obligations
+and PyPI metadata misleads. These tests lock that invariant in place.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+EXPECTED_LICENSE = "GPL-3.0-only"
+EXPECTED_CLASSIFIER = (
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)"
+)
+
+
+def _root_setup_kwargs() -> dict:
+    """Build the root GUI package setup kwargs via runpy in-process.
+
+    Importing ``setup`` would trigger the full setuptools machinery; running
+    the file as a script and capturing ``setup()`` kwargs keeps the test cheap
+    and side-effect free.
+    """
+    import runpy
+    import sys
+
+    captured: dict = {}
+    import setuptools
+
+    def _fake_setup(**kwargs) -> None:
+        captured.update(kwargs)
+
+    _orig_setup = setuptools.setup
+    setuptools.setup = _fake_setup
+    try:
+        # setup.py inserts <repo>/shared into sys.path itself.
+        runpy.run_path(
+            str(_PROJECT_ROOT / "setup.py"),
+            run_name="__airunner_setup_probe__",
+        )
+    finally:
+        setuptools.setup = _orig_setup
+        sys.modules.pop("setup", None)
+    assert captured, "root setup() was not called"
+    return captured
+
+
+def test_repo_root_license_is_gpl_with_copyright() -> None:
+    """The LICENSE file is the full GPL-3.0 text and carries a copyright line."""
+    text = (_PROJECT_ROOT / "LICENSE").read_text(encoding="utf-8")
+    assert "GNU GENERAL PUBLIC LICENSE" in text
+    assert "Version 3" in text
+    assert "Copyright" in text, "LICENSE must carry a copyright notice"
+
+
+def test_root_setup_metadata_is_gpl() -> None:
+    kwargs = _root_setup_kwargs()
+    assert kwargs["license"] == EXPECTED_LICENSE
+    assert EXPECTED_CLASSIFIER in kwargs["classifiers"]
+
+
+def test_services_and_native_metadata_are_gpl() -> None:
+    """Both builder surfaces share airunner_common metadata and must agree."""
+    from airunner_common.package_metadata import (  # noqa: E402
+        build_native_setup_kwargs,
+        build_services_setup_kwargs,
+        LICENSE_CLASSIFIERS,
+    )
+
+    assert LICENSE_CLASSIFIERS == [EXPECTED_CLASSIFIER]
+    for kwargs in (
+        build_services_setup_kwargs(package_source_dir="src"),
+        build_native_setup_kwargs(package_source_dir="src"),
+    ):
+        assert kwargs["license"] == EXPECTED_LICENSE
+        assert kwargs["classifiers"] == LICENSE_CLASSIFIERS
+
+
+def test_vendored_services_setup_metadata_is_gpl() -> None:
+    """services/setup.py is self-contained; its vendored metadata must agree."""
+    import runpy
+    import sys
+
+    captured: dict = {}
+    import setuptools
+
+    def _fake_setup(**kwargs) -> None:
+        captured.update(kwargs)
+
+    _orig_setup = setuptools.setup
+    setuptools.setup = _fake_setup
+    try:
+        runpy.run_path(
+            str(_PROJECT_ROOT / "services" / "setup.py"),
+            run_name="__airunner_services_setup_probe__",
+        )
+    finally:
+        setuptools.setup = _orig_setup
+        sys.modules.pop("setup", None)
+    assert captured, "services setup() was not called"
+    assert captured["license"] == EXPECTED_LICENSE
+    assert EXPECTED_CLASSIFIER in captured["classifiers"]
+
+
+def test_vendored_native_setup_metadata_is_gpl() -> None:
+    """native/setup.py is self-contained; its vendored metadata must agree."""
+    import runpy
+    import sys
+
+    captured: dict = {}
+    import setuptools
+
+    def _fake_setup(**kwargs) -> None:
+        captured.update(kwargs)
+
+    _orig_setup = setuptools.setup
+    setuptools.setup = _fake_setup
+    try:
+        runpy.run_path(
+            str(_PROJECT_ROOT / "native" / "setup.py"),
+            run_name="__airunner_native_setup_probe__",
+        )
+    finally:
+        setuptools.setup = _orig_setup
+        sys.modules.pop("setup", None)
+    assert captured, "native setup() was not called"
+    assert captured["license"] == EXPECTED_LICENSE
+    assert EXPECTED_CLASSIFIER in captured["classifiers"]
+
+
+def test_readme_badge_declares_gpl() -> None:
+    """The README license badge must agree with the metadata."""
+    readme = (_PROJECT_ROOT / "README.md").read_text(encoding="utf-8")
+    assert "License: GPL v3" in readme
+    assert "License-GPLv3-blue" in readme

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(_REPO_ROOT / "shared"))
 from airunner_common.package_metadata import (  # noqa: E402
     DEVELOPMENT_REQUIREMENTS,
     FACEHUGGERSHIELD_REQUIREMENT,
+    LICENSE_CLASSIFIERS,
     VERSION,
 )
 
@@ -106,6 +107,7 @@ setup(
     long_description_content_type="text/markdown",
     keywords="llm, pyside6, gui, local llm, stable diffusion, generative ai, local chatgpt, text-to-speech, speech-to-text, open source chatbot, python ai runner",
     license="GPL-3.0-only",
+    classifiers=LICENSE_CLASSIFIERS,
     author_email="contact@capsizegames.com",
     url="https://github.com/Capsize-Games/airunner",
     # The top-level scripts/ directory is developer tooling only and must not

--- a/shared/airunner_common/package_metadata.py
+++ b/shared/airunner_common/package_metadata.py
@@ -25,6 +25,14 @@ FACEHUGGERSHIELD_REQUIREMENT = (
     "#sha256=3430bb3363def8d0097a903ca106a4e944ff4a36f5a6fd374f06970090723482"
 )
 
+# The project is GPL-3.0-only (issue #2058): the repo-root LICENSE file, every
+# ``license=`` metadata field and these PyPI classifiers must agree. Vendored
+# MIT/Apache-2.0 components (melo, openvoice, z_image) are compatible with GPL
+# distribution; see THIRD_PARTY_NOTICES.md.
+LICENSE_CLASSIFIERS = [
+    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+]
+
 # The shared package lives at <repo>/shared/airunner_common, so the repo root
 # is two parents up (``shared`` and the repo root itself).
 README = (
@@ -395,6 +403,7 @@ def build_services_setup_kwargs(*, package_source_dir: str) -> dict[str, Any]:
         "long_description": README,
         "long_description_content_type": "text/markdown",
         "license": "GPL-3.0-only",
+        "classifiers": LICENSE_CLASSIFIERS,
         "author_email": "contact@capsizegames.com",
         "url": "https://github.com/Capsize-Games/airunner",
         "package_dir": {"": package_source_dir},
@@ -440,6 +449,7 @@ def build_native_setup_kwargs(*, package_source_dir: str) -> dict[str, Any]:
         "long_description": README,
         "long_description_content_type": "text/markdown",
         "license": "GPL-3.0-only",
+        "classifiers": LICENSE_CLASSIFIERS,
         "author_email": "contact@capsizegames.com",
         "url": "https://github.com/Capsize-Games/airunner",
         "package_dir": {"": package_source_dir},
@@ -460,6 +470,7 @@ __all__ = [
     "FACEHUGGERSHIELD_REQUIREMENT",
     "GRUUT_SUPPORT_REQUIREMENTS",
     "HUGGINGFACE_REQUIREMENTS",
+    "LICENSE_CLASSIFIERS",
     "LLM_NATIVE_REQUIREMENTS",
     "LLM_WEATHER_REQUIREMENTS",
     "MELOTTS_REQUIREMENTS",

--- a/shared/setup.py
+++ b/shared/setup.py
@@ -4,6 +4,7 @@ from setuptools import setup
 
 from airunner_common.package_metadata import (
     FACEHUGGERSHIELD_REQUIREMENT,
+    LICENSE_CLASSIFIERS,
     README,
     VERSION,
 )
@@ -17,6 +18,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     license="GPL-3.0-only",
+    classifiers=LICENSE_CLASSIFIERS,
     author_email="contact@capsizegames.com",
     url="https://github.com/Capsize-Games/airunner",
     package_dir={"": "."},


### PR DESCRIPTION
## Summary

Closes #2058 and #2064.

### #2058 — License conflict (GPL-3.0 vs Apache-2.0)

The repo `LICENSE` is full GPL-3.0 text with a copyright notice
(`Airunner — Copyright (C) 2026 Capsize LLC`), and the prior audit commit
already set `license="GPL-3.0-only"` on all four package surfaces. This PR
closes the remaining gaps so the **GitHub license detector, PyPI metadata and
README all agree**:

- Added `LICENSE_CLASSIFIERS` (the OSI `GPLv3` classifier) as a single source
  in `shared/airunner_common/package_metadata.py` and wired it into the
  services/native setup kwargs and the root GUI `setup.py`; mirrored the
  constant in the self-contained `services/setup.py` and `native/setup.py`
- Added the shared package (`airunner-common`) classifier wiring
- Added a `License: GPL v3` badge to `README.md`
- Added `services/tests/test_license_consistency.py` locking LICENSE + metadata
  + classifier + badge agreement

**Decision taken:** GPL-3.0-only (matches the existing LICENSE text and the
`GPL-3.0-only` metadata already merged; vendored MIT/Apache-2.0 components
remain compatible with GPL distribution per `THIRD_PARTY_NOTICES.md`).

### #2064 — Build-system isolation for services/

The code fix landed in the prior audit commit (6a0885ecd): `services/setup.py`
vendors its build metadata (no `airunner_common` import at setup time) and
`services/pyproject.toml` declares a PEP 517 `[build-system]` with only
setuptools+wheel. This PR adds a regression guard:

- `services/tests/test_build_isolation.py` asserting neither `services/setup.py`
  nor `native/setup.py` imports `airunner_common` at module level, and that
  `services/pyproject.toml` declares a build backend

## Verification (real)

- `pip wheel ./services` in a clean isolated PEP 517 env → builds
  `airunner_services-6.0.0-py3-none-any.whl` (no ModuleNotFoundError)
- `pip wheel ./native`, `pip wheel ./shared`, `pip wheel .` all build cleanly
- Every wheel METADATA contains `License: GPL-3.0-only` and
  `Classifier: License :: OSI Approved :: GNU General Public License v3 (GPLv3)`
- New tests: `test_license_consistency.py` (6), `test_build_isolation.py` (3),
  plus existing `test_third_party_notices.py` (4) → **13 passed**

## Commits

- `4f0ef5390` fix(legal): make GPL-3.0-only license consistent across all metadata (#2058)
- `a8e4d9cad` test(pkg): guard services/native build-system isolation (#2064)