### PR TITLE
fix(packaging,art): verify and lock build isolation + config-derived Z-Image dir (issues #2065, #2066)

### DIFF
--- a/.github/workflows/eval-tests.yml
+++ b/.github/workflows/eval-tests.yml
@@ -60,6 +60,8 @@ jobs:
             services/tests/test_legacy_api_surface.py \
             services/tests/test_loopback_auth.py \
             services/tests/test_secret_storage.py \
+            services/tests/test_native_package_isolation.py \
+            services/tests/test_zimage_model_dir_config.py \
             -v \
             --tb=short \
             --junitxml=runtime-contracts.xml

--- a/services/tests/test_native_package_isolation.py
+++ b/services/tests/test_native_package_isolation.py
@@ -1,0 +1,154 @@
+"""Regression tests for issue #2065: native/ build-system isolation.
+
+The native package must build through the standard PEP 517 isolated path
+(``pip wheel native/``) without importing ``airunner_common`` at setup time.
+
+Issue #2065 proposed two acceptable fixes; the repo chose the second option
+("inline the metadata"): ``native/setup.py`` vendors the build metadata
+statically (issue #2038) and ``native/pyproject.toml`` declares a
+self-contained ``[build-system]`` that only needs setuptools+wheel from the
+index. ``airunner-common`` is not published to PyPI, so it must never be
+fetched into the isolated build environment.
+
+These tests pin the acceptance criteria:
+- ``native/setup.py`` contains no ``airunner_common`` import.
+- ``native/pyproject.toml`` declares a setuptools build backend without
+  pulling ``airunner-common`` into the isolated build env.
+- The vendored metadata still matches
+  ``shared/airunner_common/package_metadata.py`` so the surfaces cannot
+  drift apart (architecture audit finding O1).
+"""
+
+from __future__ import annotations
+
+import ast
+import tomllib
+from pathlib import Path
+
+from airunner_common import package_metadata
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_NATIVE_DIR = _PROJECT_ROOT / "native"
+_SETUP_PY = _NATIVE_DIR / "setup.py"
+_PYPROJECT_TOML = _NATIVE_DIR / "pyproject.toml"
+
+
+def _module_assignments(source: str) -> dict[str, ast.AST]:
+    """Return module-level ``name -> value node`` for one setup.py source."""
+    tree = ast.parse(source)
+    assignments: dict[str, ast.AST] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assignments[target.id] = node.value
+    return assignments
+
+
+def _evaluate_node(node: ast.AST, assignments: dict[str, ast.AST]) -> object:
+    """Statically evaluate the subset of Python used by the vendored values.
+
+    Supports string constants, string ``f-strings`` (``VERSION``
+    interpolation), ``Name`` references and flat string lists — everything
+    ``native/setup.py`` uses for its vendored metadata. Anything else fails
+    loudly so a metadata edit that outgrows this evaluator is reviewed.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return _evaluate_node(assignments[node.id], assignments)
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for value in node.values:
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                parts.append(value.value)
+            elif isinstance(value, ast.FormattedValue):
+                inner = _evaluate_node(value.value, assignments)
+                if not isinstance(inner, str):
+                    raise AssertionError(
+                        "f-string interpolation must resolve to str, "
+                        f"got {inner!r}"
+                    )
+                parts.append(inner)
+            else:
+                raise AssertionError(
+                    f"unsupported JoinedStr value: {ast.dump(value)}"
+                )
+        return "".join(parts)
+    if isinstance(node, ast.List):
+        return [_evaluate_node(elt, assignments) for elt in node.elts]
+    raise AssertionError(f"unsupported setup.py node: {ast.dump(node)}")
+
+
+def test_setup_py_has_no_airunner_common_import() -> None:
+    """native/setup.py must not import airunner_common at setup time."""
+    source = _SETUP_PY.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("airunner_common"), (
+                    f"native/setup.py imports {alias.name!r}; build isolation "
+                    "for pip wheel native/ would fail"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            assert node.module is None or not node.module.startswith(
+                "airunner_common"
+            ), (
+                f"native/setup.py imports {node.module!r}; build isolation "
+                "for pip wheel native/ would fail"
+            )
+
+    # Belt-and-braces: no textual import statement either (e.g. a dynamic
+    # import built from a string).
+    for line in source.splitlines():
+        stripped = line.strip()
+        assert not stripped.startswith("import airunner_common"), (
+            f"native/setup.py contains {stripped!r}"
+        )
+        assert not stripped.startswith("from airunner_common"), (
+            f"native/setup.py contains {stripped!r}"
+        )
+
+
+def test_pyproject_build_system_is_self_contained() -> None:
+    """native/pyproject.toml must not fetch airunner-common in isolation."""
+    with _PYPROJECT_TOML.open("rb") as handle:
+        data = tomllib.load(handle)
+    build_system = data["build-system"]
+
+    assert build_system["build-backend"] == "setuptools.build_meta"
+
+    requires = build_system["requires"]
+    assert any(req.startswith("setuptools") for req in requires)
+    assert "wheel" in requires
+    # airunner-common is not published to PyPI; the isolated build env must
+    # never try to resolve it. The vendored setup.py is the isolation
+    # boundary (issue #2065, option 2).
+    assert not any("airunner-common" in req for req in requires), (
+        f"isolated build would try to fetch airunner-common: {requires}"
+    )
+
+
+def test_vendored_metadata_matches_package_metadata() -> None:
+    """The vendored values in native/setup.py must match the shared source.
+
+    native/setup.py is intentionally static (no build-time airunner_common
+    import), so this test is the drift guard that keeps it in sync with
+    shared/airunner_common/package_metadata.py.
+    """
+    assignments = _module_assignments(_SETUP_PY.read_text(encoding="utf-8"))
+
+    assert _evaluate_node(assignments["VERSION"], assignments) == (
+        package_metadata.VERSION
+    )
+    assert _evaluate_node(
+        assignments["FACEHUGGERSHIELD_REQUIREMENT"], assignments
+    ) == package_metadata.FACEHUGGERSHIELD_REQUIREMENT
+    assert _evaluate_node(
+        assignments["NATIVE_BASE_REQUIREMENTS"], assignments
+    ) == package_metadata.NATIVE_BASE_REQUIREMENTS
+    assert _evaluate_node(
+        assignments["NATIVE_CONSOLE_SCRIPTS"], assignments
+    ) == package_metadata.NATIVE_CONSOLE_SCRIPTS

--- a/services/tests/test_zimage_model_dir_config.py
+++ b/services/tests/test_zimage_model_dir_config.py
@@ -1,0 +1,80 @@
+"""Regression tests for issue #2066: config-derived Z-Image model dir.
+
+``resolve_zimage_txt2img_dir`` must derive the Z-Image txt2img directory
+from the configured service base path — never from hardcoded developer or
+container home directories. The previous implementation fell back to
+``/home/airunner/.local/share/...`` and ``/home/joe/.local/share/...``,
+which made model version resolution correct only on those machines.
+
+Acceptance criteria pinned here:
+- ``services/src/airunner_services/api/routes/art_model_versions.py``
+  contains no ``/home/airunner`` or ``/home/joe`` literal.
+- The route resolves the directory as
+  ``Path(service_base_path()) / "art" / "models" / "Z-Image Turbo" / "txt2img"``.
+- A non-existent config-derived path returns an empty string (no wrong
+  fallback path on machines where the models are not installed).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from airunner_services.api.routes import art_model_versions
+
+_ROUTE_FILE = Path(art_model_versions.__file__).resolve()
+
+
+def _source_text() -> str:
+    return _ROUTE_FILE.read_text(encoding="utf-8")
+
+
+def test_no_hardcoded_home_fallbacks_in_route() -> None:
+    """No developer/container home paths survive in the route source."""
+    matches = re.findall(r"home/(?:airunner|joe)", _source_text())
+    assert not matches, (
+        "resolve_zimage_txt2img_dir must not contain hardcoded "
+        f"home fallbacks; found: {matches}"
+    )
+
+
+def test_zimage_dir_derived_from_service_base_path(monkeypatch, tmp_path) -> None:
+    """The txt2img dir follows the configured service base path."""
+    txt2img = tmp_path / "art" / "models" / "Z-Image Turbo" / "txt2img"
+    txt2img.mkdir(parents=True)
+
+    # The route resolves paths relative to service_base_path(); a real
+    # database round-trip is out of scope for this regression test, so pin
+    # the base path directly.
+    monkeypatch.setattr(
+        art_model_versions,
+        "service_base_path",
+        lambda: tmp_path,
+    )
+
+    assert art_model_versions.resolve_zimage_txt2img_dir() == str(txt2img)
+
+
+def test_zimage_dir_returns_empty_when_missing(monkeypatch, tmp_path) -> None:
+    """A missing config-derived dir yields an empty string, not a fallback."""
+    monkeypatch.setattr(
+        art_model_versions,
+        "service_base_path",
+        lambda: tmp_path,
+    )
+
+    assert art_model_versions.resolve_zimage_txt2img_dir() == ""
+
+
+def test_route_resolves_through_service_base_path_only() -> None:
+    """The derivation must be a single config-derived expression.
+
+    The function must build its candidate from ``service_base_path()`` and
+    must not keep a list of alternate home-directory fallbacks (the pre-#2066
+    implementation iterated ``candidates``).
+    """
+    function_source = _source_text().split("def resolve_zimage_txt2img_dir")[1]
+    assert "service_base_path()" in function_source
+    assert "candidates" not in function_source
+    assert "Z-Image Turbo" in function_source
+    assert "/home" not in function_source


### PR DESCRIPTION
## Summary

Both fixes for issues **#2065** and **#2066** already landed on `master` inside
broader audit commits (`6a0885ecd` for the packaging work, `5cf47fce4` for the
art route work) but were never linked to the issues, so they stayed open.
This PR verifies the acceptance criteria for real and adds regression tests
that pin each criterion so they can't silently regress, plus wires them into
the CI contract suite.

### Issue #2065 — build-system isolation for `native/`

Verified:
- `pip wheel ./native` succeeds through the standard PEP 517 isolated path
  (no `--no-build-isolation`): the isolated env only installs
  `setuptools>=80.9.0` + `wheel` from `native/pyproject.toml`.
- `native/setup.py` has no `airunner_common` import at setup time — the
  metadata is vendored statically (issue #2038), keeping the build isolated.

Added: `services/tests/test_native_package_isolation.py`
- AST + text check: no `airunner_common` import in `native/setup.py`
- `native/pyproject.toml` `[build-system]` stays self-contained (never fetches
  `airunner-common`, which is not on PyPI)
- vendored `native/setup.py` metadata still matches
  `shared/airunner_common/package_metadata.py` (drift guard, O1)

### Issue #2066 — config-derived Z-Image model dir

Verified:
- `grep -nE 'home/airunner|home/joe' services/src/airunner_services/api/routes/art_model_versions.py` → no matches
- `resolve_zimage_txt2img_dir` derives the path as
  `Path(service_base_path()) / "art" / "models" / "Z-Image Turbo" / "txt2img"`

Added: `services/tests/test_zimage_model_dir_config.py`
- no hardcoded `/home/airunner` or `/home/joe` literals in the route
- dir resolves from the configured base path (monkeypatched, no DB needed)
- missing dir returns `""` — no wrong fallback path on non-developer installs
- the route resolves only through `service_base_path()` (no candidate list)

### CI
- `.github/workflows/eval-tests.yml`: both new test files added to the
  `runtime-contract-tests` job.

## Test results

- New regression tests: **7 passed** (3 for #2065, 4 for #2066)
- Full runtime contract suite: **47 passed**
- Full `services/tests` (non-eval): **117 passed, 7 skipped, 2 failed**
  — the 2 failures (`test_llm_functional.py::test_llm_end_to_end_without_gui[qwen3.5-9b]`,
  `test_gui_llm_tts_functional.py::test_gui_llm_conversation_progresses_without_audio_output`)
  require real model artifacts (`qwen3.5-9b` GGUF, OpenVoice TTS assets) that are
  not installed in this environment; they fail identically on the unmodified
  baseline and are unrelated to these changes. Eval tests additionally need a
  real LLM and are marked `eval`/`slow`/`integration` (not run in CI contract job).

Closes #2065, Closes #2066.