### PR TITLE
fix: SSRF/file-write, packaging deps, Dockerfile, CI hermetic suite (#2029 #2037 #2039 #2054)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,13 +121,19 @@ COPY native/ ./native/
 # (issue #2038), so --no-build-isolation is no longer required; ./shared is
 # still installed first because services/native declare airunner-common as a
 # runtime dependency.
+# The services extras pin CUDA builds of torch (torch==2.13.0+cu129 etc.),
+# which are only published on the PyTorch CUDA index (download.pytorch.org),
+# not PyPI; the extra index is passed to the services install so the pinned
+# +cu129 wheels resolve inside the CUDA base image.
 RUN set -e; \
     service_profiles="$(printf '%s' ",${AIRUNNER_INSTALL_PROFILES}," | sed 's/,gui,/,/g')"; \
     service_profiles="${service_profiles#,}"; \
     service_profiles="${service_profiles%,}"; \
     python3.13 -m pip install -e ./shared; \
     if [ -n "${service_profiles}" ]; then \
-        python3.13 -m pip install -e "./services[${service_profiles}]"; \
+        python3.13 -m pip install \
+            --extra-index-url https://download.pytorch.org/whl/cu129 \
+            -e "./services[${service_profiles}]"; \
     else \
         python3.13 -m pip install -e ./services; \
     fi; \

--- a/services/src/airunner_services/api/routes/art.py
+++ b/services/src/airunner_services/api/routes/art.py
@@ -9,7 +9,6 @@ from fastapi import APIRouter
 
 from .art_catalog_routes import router as catalog_router
 from .catalog_bootstrap import router as catalog_bootstrap_router
-from .vram import router as vram_router
 from .art_contracts import (
     ArtComponentResponse,
     BackgroundRemovalRequest,
@@ -28,7 +27,18 @@ router.include_router(generation_router)
 router.include_router(management_router)
 router.include_router(catalog_router)
 router.include_router(catalog_bootstrap_router)
-router.include_router(vram_router)
+# The vram route module imports torch at module import time; the API server
+# must be importable (and testable) in torch-free installs, so the router is
+# attached lazily here (issue #2054).
+try:
+    from .vram import router as vram_router
+
+    router.include_router(vram_router)
+except ImportError as exc:
+    # torch (or safetensors) is not installed; the VRAM endpoint is
+    # unavailable but the rest of the API surface still serves.
+    if exc.name not in {"torch", "safetensors"}:
+        raise
 
 __all__ = [
     "ArtComponentResponse",

--- a/services/src/airunner_services/api/routes/hardware.py
+++ b/services/src/airunner_services/api/routes/hardware.py
@@ -7,13 +7,25 @@ import logging
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 
-from airunner_services.model_management.hardware_profiler import (
-    HardwareProfiler,
-)
+# HardwareProfiler imports torch; the profiler is resolved lazily so the API
+# server can import in torch-free installs (issue #2054).
+_profiler: "HardwareProfiler | None" = None
+
+
+def _get_profiler() -> "HardwareProfiler":
+    """Return the process-wide hardware profiler, resolving it on first use."""
+    global _profiler
+    if _profiler is None:
+        from airunner_services.model_management.hardware_profiler import (
+            HardwareProfiler,
+        )
+
+        _profiler = HardwareProfiler()
+    return _profiler
+
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-_profiler = HardwareProfiler()
 
 
 class HardwareProfileResponse(BaseModel):
@@ -33,7 +45,7 @@ class HardwareProfileResponse(BaseModel):
 @router.get("/hardware", response_model=HardwareProfileResponse)
 async def hardware_profile() -> HardwareProfileResponse:
     """Return the current hardware profile from the host machine."""
-    profile = _profiler.get_profile()
+    profile = _get_profiler().get_profile()
     return HardwareProfileResponse(
         total_vram_gb=profile.total_vram_gb,
         available_vram_gb=profile.available_vram_gb,

--- a/services/src/airunner_services/daemon_client/gui_daemon_client.py
+++ b/services/src/airunner_services/daemon_client/gui_daemon_client.py
@@ -9,13 +9,13 @@ import signal
 import subprocess
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 from typing import Any, Callable, Dict, Iterable, Optional
 from urllib.parse import urlencode
 
 import requests
 
 from airunner_services.runtimes.daemon_config import DaemonConfig
-from airunner_services.llm.llm_request import LLMRequest
 from airunner_services.daemon_connection_state import (
     DaemonConnectionState,
 )
@@ -27,7 +27,19 @@ from airunner_services.api.loopback_token import (
 from airunner_common.dev_build_token import current_dev_build_token
 from airunner_common.contract_enums import LLMActionType, SignalCode
 from airunner_common.settings import AIRUNNER_LOG_LEVEL
-from airunner_services.utils.application import get_logger
+
+if TYPE_CHECKING:
+    # The service-owned LLMRequest dataclass pulls in the database layer,
+    # which (transitively) imports torch at module import time. The GUI
+    # package deliberately keeps torch optional, so this import must stay
+    # lazy: daemon-client consumers only use duck-typed request objects
+    # (to_dict()/attributes), never the service class itself (issue #2037).
+    from airunner_services.llm.llm_request import LLMRequest
+
+# get_logger is imported from its leaf module (not the utils.application
+# package __init__) so that importing the daemon client does not transitively
+# import torch via the application utility package (issue #2037).
+from airunner_services.utils.application.get_logger import get_logger
 
 StateCallback = Callable[[DaemonConnectionState, str], None]
 _ART_JOB_POLL_INTERVAL_SECONDS = 0.10
@@ -678,7 +690,7 @@ class GuiDaemonClient(GuiBridgeMixin):
     def stream_llm_request(
         self,
         prompt: str,
-        llm_request: LLMRequest,
+        llm_request: "LLMRequest",
         action: LLMActionType,
         request_id: str,
         *,
@@ -1100,7 +1112,7 @@ class GuiDaemonClient(GuiBridgeMixin):
     @staticmethod
     def _llm_payload(
         prompt: str,
-        llm_request: LLMRequest,
+        llm_request: "LLMRequest",
         action: LLMActionType,
         *,
         search_hints: Optional[Dict[str, Any]],
@@ -1123,7 +1135,7 @@ class GuiDaemonClient(GuiBridgeMixin):
         return payload
 
     @staticmethod
-    def _llm_request_fields(llm_request: LLMRequest) -> Dict[str, Any]:
+    def _llm_request_fields(llm_request: "LLMRequest") -> Dict[str, Any]:
         """Return JSON-safe fields that the daemon legacy route understands."""
         payload = llm_request.to_dict()
         extra_fields = {

--- a/services/src/airunner_services/downloads/huggingface_download_worker.py
+++ b/services/src/airunner_services/downloads/huggingface_download_worker.py
@@ -7,11 +7,6 @@ import requests
 
 from airunner_common.contract_enums import SignalCode
 from airunner_common.settings import AIRUNNER_BASE_PATH, MODELS_DIR
-from airunner_services.art.managers.zimage.zimage_bundle_requirements import (
-    find_active_checkpoint,
-    get_active_zimage_load_mode,
-    get_downloadable_files_for_mode,
-)
 from airunner_services.bootstrap.model_bootstrap_data import (
     model_bootstrap_data,
 )
@@ -536,6 +531,14 @@ class HuggingFaceDownloadWorker(BaseDownloadWorker):
         """Return a lean bootstrap subset when an FP8 checkpoint already exists."""
         if not bootstrap_files:
             return bootstrap_files
+        # Imported lazily: zimage_bundle_requirements imports torch, and this
+        # module must stay importable in torch-free installs (issue #2054).
+        from airunner_services.art.managers.zimage.zimage_bundle_requirements import (
+            find_active_checkpoint,
+            get_active_zimage_load_mode,
+            get_downloadable_files_for_mode,
+        )
+
         checkpoint = find_active_checkpoint(output_dir)
         if checkpoint is None:
             return bootstrap_files
@@ -562,6 +565,14 @@ class HuggingFaceDownloadWorker(BaseDownloadWorker):
         """Drop Z-Image missing files that are not needed for the active load mode."""
         if not missing_files:
             return missing_files
+        # Imported lazily: zimage_bundle_requirements imports torch, and this
+        # module must stay importable in torch-free installs (issue #2054).
+        from airunner_services.art.managers.zimage.zimage_bundle_requirements import (
+            find_active_checkpoint,
+            get_active_zimage_load_mode,
+            get_downloadable_files_for_mode,
+        )
+
         checkpoint = find_active_checkpoint(output_dir)
         if checkpoint is None:
             return missing_files

--- a/services/src/airunner_services/model_management/__init__.py
+++ b/services/src/airunner_services/model_management/__init__.py
@@ -1,29 +1,17 @@
-from airunner_services.model_management.base_model_manager import (
-    BaseModelManager,
-)
-from airunner_services.model_management.hardware_profiler import (
-    HardwareProfiler,
-)
+"""Service-owned model management helpers.
+
+The package deliberately avoids importing torch at module import time: several
+submodules (base_model_manager, hardware_profiler, memory_allocator,
+model_resource_manager, model_load_balancer) import torch eagerly, and the
+GUI/CI surfaces that import this package (e.g. the API route catalog) must
+work without a torch install. Torch-dependent exports are resolved lazily via
+``__getattr__`` (same pattern as ``airunner_services.utils.application``).
+"""
+
 from airunner_services.model_management.model_manager_interface import (
     ModelManagerInterface,
 )
-from airunner_services.model_management.quantization_strategy import (
-    QuantizationStrategy,
-)
 from airunner_services.model_management.model_registry import ModelRegistry
-from airunner_services.model_management.memory_allocator import (
-    MemoryAllocator,
-)
-from airunner_services.model_management.model_resource_manager import (
-    ModelResourceManager,
-    ModelState,
-)
-from airunner_services.model_management.canvas_memory_tracker import (
-    CanvasMemoryTracker,
-)
-from airunner_services.model_management.model_load_balancer import (
-    ModelLoadBalancer,
-)
 
 __all__ = [
     "BaseModelManager",
@@ -37,3 +25,56 @@ __all__ = [
     "CanvasMemoryTracker",
     "ModelLoadBalancer",
 ]
+
+
+def __getattr__(name: str):
+    """Resolve torch-dependent model-management exports lazily."""
+    if name == "BaseModelManager":
+        from airunner_services.model_management.base_model_manager import (
+            BaseModelManager,
+        )
+
+        return BaseModelManager
+    if name == "HardwareProfiler":
+        from airunner_services.model_management.hardware_profiler import (
+            HardwareProfiler,
+        )
+
+        return HardwareProfiler
+    if name == "QuantizationStrategy":
+        from airunner_services.model_management.quantization_strategy import (
+            QuantizationStrategy,
+        )
+
+        return QuantizationStrategy
+    if name == "MemoryAllocator":
+        from airunner_services.model_management.memory_allocator import (
+            MemoryAllocator,
+        )
+
+        return MemoryAllocator
+    if name == "ModelResourceManager":
+        from airunner_services.model_management.model_resource_manager import (
+            ModelResourceManager,
+        )
+
+        return ModelResourceManager
+    if name == "ModelState":
+        from airunner_services.model_management.model_resource_manager import (
+            ModelState,
+        )
+
+        return ModelState
+    if name == "CanvasMemoryTracker":
+        from airunner_services.model_management.canvas_memory_tracker import (
+            CanvasMemoryTracker,
+        )
+
+        return CanvasMemoryTracker
+    if name == "ModelLoadBalancer":
+        from airunner_services.model_management.model_load_balancer import (
+            ModelLoadBalancer,
+        )
+
+        return ModelLoadBalancer
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/services/src/airunner_services/url_safety.py
+++ b/services/src/airunner_services/url_safety.py
@@ -27,9 +27,38 @@ class SSRFBlocked(ValueError):
         return self.reason
 
 
+# NAT64 prefixes that embed an IPv4 address in the low 32 bits (RFC 6052
+# well-known prefix and RFC 8215 local-use prefix). ``ipaddress.is_global``
+# reports True for these prefixes because they are globally routed, even when
+# the embedded IPv4 is loopback/private -- so the embedded address must be
+# checked explicitly or ``http://[64:ff9b::7f00:1]/`` becomes a loopback
+# SSRF vector on NAT64 networks (issue #2029).
+_NAT64_EMBEDDING_PREFIXES = (
+    ipaddress.ip_network("64:ff9b::/96"),
+    ipaddress.ip_network("64:ff9b:1::/48"),
+)
+
+# Deprecated 6to4 relay anycast (RFC 7526). Legacy routers may still forward
+# these; treat the range as disallowed for outbound fetches.
+_6TO4_RELAY_ANYCAST = ipaddress.ip_network("192.88.99.0/24")
+
+
 def _is_ip_disallowed(ip: ipaddress._BaseAddress) -> bool:
     """Return True when one IP should be blocked for outbound fetches."""
-    return not bool(ip.is_global)
+    if not ip.is_global:
+        return True
+    # Multicast addresses are not routable fetch targets even though some
+    # multicast ranges report ``is_global`` True.
+    if ip.is_multicast:
+        return True
+    if isinstance(ip, ipaddress.IPv6Address) and any(
+        ip in prefix for prefix in _NAT64_EMBEDDING_PREFIXES
+    ):
+        embedded_ipv4 = ipaddress.ip_address(int(ip) & 0xFFFFFFFF)
+        return _is_ip_disallowed(embedded_ipv4)
+    if isinstance(ip, ipaddress.IPv4Address) and ip in _6TO4_RELAY_ANYCAST:
+        return True
+    return False
 
 
 def _allowed_host_set() -> frozenset[str]:

--- a/services/src/airunner_services/utils/application/__init__.py
+++ b/services/src/airunner_services/utils/application/__init__.py
@@ -22,9 +22,6 @@ from airunner_services.utils.application.enum_resolver import (
 )
 from airunner_services.utils.application.enum_resolver import signal_code_proxy
 from airunner_services.utils.application.get_logger import get_logger
-from airunner_services.utils.application.get_torch_device import (
-    get_torch_device,
-)
 from airunner_services.utils.application.get_version import get_version
 from airunner_services.utils.application.mediator_mixin import (
     MediatorMixin,
@@ -75,4 +72,14 @@ def __getattr__(name: str):
         )
 
         return RuntimeContextMixin
+    if name == "get_torch_device":
+        # get_torch_device imports torch at module import time. The GUI
+        # package keeps torch optional, so importing the application utility
+        # package must not force a torch install. Resolve it lazily only when
+        # torch-dependent code actually calls it (issue #2037).
+        from airunner_services.utils.application.get_torch_device import (
+            get_torch_device,
+        )
+
+        return get_torch_device
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/services/src/airunner_services/utils/text/__init__.py
+++ b/services/src/airunner_services/utils/text/__init__.py
@@ -1,6 +1,5 @@
 """Service-owned text helpers."""
 
-from airunner_services.utils.text.language_detection import detect_language
 from airunner_services.utils.text.formatter import Formatter
 from airunner_services.utils.text.formatter_extended import (
 	FormatterExtended,
@@ -34,3 +33,18 @@ __all__ = [
 	"roman_to_int",
 	"strip_emoji_characters",
 ]
+
+
+def __getattr__(name: str):
+	"""Resolve optional text exports lazily.
+
+	``language_detection`` imports the optional ``lingua`` package at module
+	import time. Importing the text-helpers package (which the download
+	workers pull in) must not require lingua, so the language-detection
+	helpers resolve only when actually used (issue #2054).
+	"""
+	if name in {"detect_language", "strip_nonlinguistic_text"}:
+		from airunner_services.utils.text import language_detection
+
+		return getattr(language_detection, name)
+	raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/services/tests/test_download_security.py
+++ b/services/tests/test_download_security.py
@@ -106,6 +106,17 @@ def test_output_dir_rejects_relative_escape(tmp_path, monkeypatch) -> None:
         "http://0.0.0.0/x",
         "http://[fe80::1]/x",
         "http://[::ffff:127.0.0.1]/x",
+        # NAT64-embedded loopback/private IPv4 (RFC 6052 / RFC 8215). These
+        # prefixes report is_global=True, so they need an explicit check.
+        "http://[64:ff9b::7f00:1]/x",
+        "http://[64:ff9b::a00:1]/x",
+        "http://[64:ff9b::ac10:1]/x",
+        "http://[64:ff9b::c0a8:101]/x",
+        "http://[64:ff9b:1::7f00:1]/x",
+        # 6to4 relay anycast (deprecated, RFC 7526).
+        "http://192.88.99.1/x",
+        # Multicast is not a valid fetch target.
+        "http://224.0.0.1/x",
     ],
 )
 def test_validate_url_for_fetch_rejects_loopback_and_private(bad_url: str) -> None:
@@ -120,6 +131,12 @@ def test_validate_url_for_fetch_rejects_bad_scheme_and_userinfo() -> None:
         validate_url_for_fetch("ftp://example.com/x")
     with pytest.raises(SSRFBlocked):
         validate_url_for_fetch("http://user:pass@example.com/x")
+
+
+def test_validate_url_for_fetch_nat64_embedded_public_ip_allowed() -> None:
+    """A NAT64 prefix embedding a public IPv4 stays fetchable (no overblock)."""
+    # 64:ff9b::808:808 embeds 8.8.8.8, which is a global address.
+    validate_url_for_fetch("http://[64:ff9b::808:808]/x")
 
 
 def test_validate_url_for_fetch_allowlist_for_intranet_mirrors(

--- a/services/tests/test_gui_llm_tts_functional.py
+++ b/services/tests/test_gui_llm_tts_functional.py
@@ -17,6 +17,13 @@ import pytest
 import yaml
 from PySide6.QtWidgets import QApplication
 
+# These daemon-backed functional suites exercise the GUI LLM/TTS stack, which
+# imports langchain-core, librosa and other optional heavy dependencies at
+# module import time. Skip cleanly in installs that lack the llm-native/tts
+# extras so the runtime-smoke/optional suites still collect (issue #2054).
+pytest.importorskip("langchain_core")
+pytest.importorskip("librosa")
+
 from llm_functional_support import BUNDLED_REFERENCE_SPEAKER
 from llm_functional_support import combined_llama_env_overrides
 from llm_functional_support import daemon_env

--- a/services/tests/test_model_load_security.py
+++ b/services/tests/test_model_load_security.py
@@ -13,6 +13,13 @@ import builtins
 import os
 import pickle
 
+import pytest
+
+# This suite exercises the melo TTS vendor, which imports torch at module
+# import time. Skip cleanly (rather than aborting collection) in torch-free
+# installs so the optional runtime-smoke suites can still run (issue #2054).
+pytest.importorskip("torch")
+
 from airunner_services.vendor.melo.text.language_base import (
     _load_g2p_cache_safe,
 )

--- a/services/tests/test_tool_sandbox_security.py
+++ b/services/tests/test_tool_sandbox_security.py
@@ -16,6 +16,12 @@ from unittest import mock
 
 import pytest
 
+# The tool manager pulls in the long-running agent stack, which imports
+# langgraph at module import time. Skip cleanly in installs that lack the
+# llm-native extras so the runtime-contract/optional suites still collect
+# (issue #2054).
+pytest.importorskip("langgraph")
+
 from airunner_services.api.routes.persistence_mutations import (
     _enforce_tool_code_values,
     _enforce_tool_safety,


### PR DESCRIPTION
## Summary

Fixes four release-blocking issues assigned to this worktree: **#2029**, **#2037**, **#2039**, **#2054**.

The bulk of each fix landed in the audit commit (`6a0885e`); this branch adds the follow-up changes that make those fixes actually hold on a **fresh torch-free clone**:

### #2054 — CI eval-tests.yml must run on a fresh clone
The audit commit pointed CI at real paths/extras, but `services/tests` still **aborted collection** on a fresh `[development]` install because several service modules import torch / lingua / langchain / langgraph at module import time. This branch:
- Makes torch-dependent service exports **lazy** (`__getattr__` / function-local imports) so the API server, download workers, daemon client and `airunner` GUI package import cleanly without torch.
- Guards optional-dep test files with `pytest.importorskip` so they **skip** instead of aborting collection.
- Result: `services/tests` collects clean; the CI runtime-contract job passes **40/40**; all four runtime-smoke suites pass; eval suite collects **46** and skips cleanly on a fresh runner.

### #2037 — GUI package declares airunner-services
`setup.py` (audit) declares `airunner-services==6.0.0`. This branch also removes the **remaining torch hard-imports** in `airunner_services.daemon_client.gui_daemon_client` and `utils.application` so `import airunner` truly works on a torch-free install.

### #2039 — Dockerfile
The audit commit fixed the extras/copies; this branch adds the missing **PyTorch CUDA index** (`--extra-index-url https://download.pytorch.org/whl/cu129`) so the pinned `torch==2.13.0+cu129` wheels resolve during `docker build` (they are not on PyPI).

### #2029 — downloads/url SSRF + file write
Fix landed in the audit commit (`validate_url_for_fetch`, safe path resolution, `_safe_filename`, redirect validation). This branch **closes three remaining SSRF blocklist gaps** that `ipaddress.is_global` alone misses:
- **NAT64 prefixes** (`64:ff9b::/96` RFC 6052, `64:ff9b:1::/48` RFC 8215) report `is_global=True` even when the embedded IPv4 is loopback/private — `http://[64:ff9b::7f00:1]/` reaches `127.0.0.1` on NAT64 networks. The embedded IPv4 is now checked explicitly.
- **6to4 relay anycast** `192.88.99.0/24` (deprecated, RFC 7526) — not a legitimate fetch target.
- **Multicast** addresses (e.g. `224.0.0.1`) — never valid outbound fetch destinations.
- A positive test proves NAT64-embedded *public* IPv4 stays fetchable (no over-blocking).

Verified end-to-end with a real local HTTP server (via the documented `AIRUNNER_SSRF_ALLOWED_HOSTS` operator allowlist for the loopback fixture): real file download to the configured root, redirect following, `../` filename rejection with no escape file written, out-of-root `output_dir` rejection, and cloud-metadata URL rejection.

## Verification (fresh venv, torch-free)

| Check | Result |
|---|---|
| CI runtime-contract job | **40 passed** |
| Download-security (#2029) | **47 passed** (39 audit + 8 new blocklist/NAT64 cases) |
| Downloader/security regression set | **69 passed** |
| Eval suite collection (`services/tests/eval -m eval`) | **46 collected, 0 errors** (model-gated, skip on missing artifacts) |
| Runtime-smoke suites (llm/stt/art/tts) | **4/4 pass** (optional, empty→pass) |
| Install dry-runs: `./shared`, `./services[development]`, `.[development]` | resolve, no phantom extras |
| `import airunner_services` download/url_safety modules | OK |
| Console scripts `airunner-headless` / `airunner-native` | present |
