### PR TITLE
feat(services): make LLM idle auto-unload env-configurable (issue #128)

### DIFF
--- a/services/src/airunner_services/workers/llm_generate_worker.py
+++ b/services/src/airunner_services/workers/llm_generate_worker.py
@@ -95,8 +95,15 @@ class LLMGenerateWorker(
 
 		self._last_request_time: Optional[float] = None
 		self._inactivity_timer: Optional[object] = None
-		self._inactivity_timeout = 300
-		self._auto_unload_enabled = False
+		# The LAN daemon deployment unloads the local GGUF model after 10
+		# minutes of inactivity. Both knobs stay OFF/5-minutes by default so
+		# existing deployments behave identically unless they opt in.
+		self._inactivity_timeout = int(
+			os.environ.get("AIRUNNER_LLM_INACTIVITY_TIMEOUT_SECONDS", "300")
+		)
+		self._auto_unload_enabled = (
+			os.environ.get("AIRUNNER_LLM_AUTO_UNLOAD", "0") == "1"
+		)
 
 	@property
 	def use_openrouter(self) -> bool:
@@ -275,7 +282,10 @@ class LLMGenerateWorker(
 		self._inactivity_timer = QTimer()
 		self._inactivity_timer.timeout.connect(self._check_inactivity)
 		self._inactivity_timer.start(60000)
-		self.logger.info("LLM auto-unload timer started (5 minute timeout)")
+		self.logger.info(
+			"LLM auto-unload timer started "
+			f"({int(self._inactivity_timeout / 60)} minute timeout)"
+		)
 
 	def _check_inactivity(self) -> None:
 		"""Unload the model after extended inactivity when enabled."""
@@ -416,6 +426,8 @@ class LLMGenerateWorker(
 		"""Start the worker thread if LLM is enabled."""
 		if self.application_settings.llm_enabled or AIRUNNER_LLM_ON:
 			self._load_llm_thread()
+		if self._auto_unload_enabled:
+			self._start_inactivity_timer()
 
 	def handle_message(self, message: Dict) -> None:
 		"""Process queued messages for LLM generation."""

--- a/services/src/airunner_services/workers/llm_generate_worker.py
+++ b/services/src/airunner_services/workers/llm_generate_worker.py
@@ -278,6 +278,8 @@ class LLMGenerateWorker(
 		"""Start the inactivity monitoring timer when auto-unload is on."""
 		if not self._auto_unload_enabled:
 			return
+		if self._inactivity_timer is not None:
+			return
 
 		self._inactivity_timer = QTimer()
 		self._inactivity_timer.timeout.connect(self._check_inactivity)
@@ -315,6 +317,8 @@ class LLMGenerateWorker(
 		"""Unload the model and stop the worker during application shutdown."""
 		self.logger.debug("Quitting LLM")
 		self.running = False
+		if self._inactivity_timer is not None:
+			self._inactivity_timer.stop()
 		if self._model_manager:
 			self._model_manager.unload()
 		if self._llm_thread is not None:
@@ -423,11 +427,36 @@ class LLMGenerateWorker(
 			self.logger.error(f"Error in on_load_conversation: {error}")
 
 	def start_worker_thread(self) -> None:
-		"""Start the worker thread if LLM is enabled."""
+		"""Start the worker thread if LLM is enabled.
+
+		Kept as a legacy compatibility hook: the daemon bootstrap does not
+		call this method (``create_worker`` connects ``worker_thread.started``
+		directly to ``run()``), so the inactivity timer is also started from
+		``run()`` to guarantee it fires in real deployments.
+		"""
 		if self.application_settings.llm_enabled or AIRUNNER_LLM_ON:
 			self._load_llm_thread()
 		if self._auto_unload_enabled:
 			self._start_inactivity_timer()
+
+	def run(self) -> None:
+		"""Start the queue-processing loop and the inactivity timer.
+
+		``create_worker`` wires ``worker_thread.started.connect(self.run)``,
+		so this is the real daemon bootstrap entry point. Starting the idle
+		auto-unload timer here (instead of only in ``start_worker_thread``,
+		which no production code calls) is what makes the LAN-daemon 10-minute
+		auto-unload actually work. The timer is idempotent, so any extra call
+		from a compatibility path is harmless.
+		"""
+		self._start_inactivity_timer()
+		super().run()
+
+	def stop(self) -> None:
+		"""Stop the queue loop, the inactivity timer, and finish."""
+		if self._inactivity_timer is not None:
+			self._inactivity_timer.stop()
+		super().stop()
 
 	def handle_message(self, message: Dict) -> None:
 		"""Process queued messages for LLM generation."""

--- a/services/tests/test_llm_generate_worker_idle_unload.py
+++ b/services/tests/test_llm_generate_worker_idle_unload.py
@@ -1,0 +1,243 @@
+"""Tests for the env-configurable LLM idle auto-unload (issue #128).
+
+The LAN daemon deployment unloads the local GGUF model after 10 minutes of
+inactivity. The worker keeps that behavior opt-in and env-configurable:
+
+- ``AIRUNNER_LLM_AUTO_UNLOAD`` (default "0") turns auto-unload on when "1".
+- ``AIRUNNER_LLM_INACTIVITY_TIMEOUT_SECONDS`` (default 300) sets the idle
+  timeout in seconds; the daemon deployment sets 600 (10 minutes).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from airunner_common.contract_enums import ModelStatus, ModelType
+from airunner_services.utils.application.runtime_primitives import QTimer
+from airunner_services.workers.llm_generate_worker import (
+    LLMGenerateWorker,
+    time as worker_time,
+)
+
+_ENV_AUTO_UNLOAD = "AIRUNNER_LLM_AUTO_UNLOAD"
+_ENV_TIMEOUT = "AIRUNNER_LLM_INACTIVITY_TIMEOUT_SECONDS"
+
+
+class _FakeModelManager:
+    """Minimal model-manager double with only the status/unload surface."""
+
+    def __init__(self, status: ModelStatus = ModelStatus.LOADED) -> None:
+        self.model_status = {ModelType.LLM: status}
+        self.unload_calls = 0
+
+    def unload(self) -> None:
+        """Record one unload call."""
+        self.unload_calls += 1
+
+
+def _make_worker(
+    auto_unload: bool = True,
+    timeout: int = 300,
+    status: ModelStatus = ModelStatus.LOADED,
+) -> LLMGenerateWorker:
+    """Return one worker wired to a fake model manager and idle knobs."""
+    worker = LLMGenerateWorker()
+    worker._model_manager = _FakeModelManager(status=status)
+    worker._auto_unload_enabled = auto_unload
+    worker._inactivity_timeout = timeout
+    return worker
+
+
+def _freeze_clock(
+    monkeypatch: pytest.MonkeyPatch, now: float
+) -> dict[str, float]:
+    """Replace ``time.time`` in the worker module with a fixed clock."""
+    fake_now = {"value": now}
+    monkeypatch.setattr(
+        worker_time,
+        "time",
+        lambda: fake_now["value"],
+    )
+    return fake_now
+
+
+class TestEnvParsing:
+    """The idle knobs read from the environment with safe defaults."""
+
+    def test_unset_env_defaults_to_off_and_300(self, monkeypatch) -> None:
+        """Unset vars keep auto-unload off with the 5-minute default."""
+        monkeypatch.delenv(_ENV_AUTO_UNLOAD, raising=False)
+        monkeypatch.delenv(_ENV_TIMEOUT, raising=False)
+
+        worker = LLMGenerateWorker()
+
+        assert worker._auto_unload_enabled is False
+        assert worker._inactivity_timeout == 300
+
+    def test_env_enables_auto_unload_with_600_second_timeout(
+        self, monkeypatch
+    ) -> None:
+        """``AIRUNNER_LLM_AUTO_UNLOAD=1`` + 600s yields on/600."""
+        monkeypatch.setenv(_ENV_AUTO_UNLOAD, "1")
+        monkeypatch.setenv(_ENV_TIMEOUT, "600")
+
+        worker = LLMGenerateWorker()
+
+        assert worker._auto_unload_enabled is True
+        assert worker._inactivity_timeout == 600
+
+    def test_env_zero_keeps_auto_unload_off(self, monkeypatch) -> None:
+        """An explicit ``0`` behaves like the default (off)."""
+        monkeypatch.setenv(_ENV_AUTO_UNLOAD, "0")
+        monkeypatch.delenv(_ENV_TIMEOUT, raising=False)
+
+        worker = LLMGenerateWorker()
+
+        assert worker._auto_unload_enabled is False
+        assert worker._inactivity_timeout == 300
+
+
+class TestInactivityCheck:
+    """``_check_inactivity`` unloads exactly at the timeout boundary."""
+
+    def test_unloads_at_exact_timeout_boundary(self, monkeypatch) -> None:
+        """inactive_time == timeout fires ``unload_llm()``."""
+        worker = _make_worker(auto_unload=True, timeout=600)
+        fake_now = _freeze_clock(monkeypatch, 1000.0)
+        worker._last_request_time = fake_now["value"] - 600
+
+        worker._check_inactivity()
+
+        assert worker._model_manager.unload_calls == 1
+        assert worker._last_request_time is None
+
+    def test_does_not_unload_one_second_before_timeout(
+        self, monkeypatch
+    ) -> None:
+        """inactive_time just below the timeout does not fire."""
+        worker = _make_worker(auto_unload=True, timeout=600)
+        fake_now = _freeze_clock(monkeypatch, 1000.0)
+        worker._last_request_time = fake_now["value"] - 599
+
+        worker._check_inactivity()
+
+        assert worker._model_manager.unload_calls == 0
+        assert worker._last_request_time == fake_now["value"] - 599
+
+    def test_skips_when_auto_unload_disabled(self, monkeypatch) -> None:
+        """Disabled auto-unload never unloads, even past the timeout."""
+        worker = _make_worker(auto_unload=False, timeout=600)
+        fake_now = _freeze_clock(monkeypatch, 1000.0)
+        worker._last_request_time = fake_now["value"] - 99999
+
+        worker._check_inactivity()
+
+        assert worker._model_manager.unload_calls == 0
+
+    def test_skips_when_no_request_timestamp(self, monkeypatch) -> None:
+        """No prior request means nothing to measure inactivity against."""
+        worker = _make_worker(auto_unload=True, timeout=600)
+        _freeze_clock(monkeypatch, 1000.0)
+        worker._last_request_time = None
+
+        worker._check_inactivity()
+
+        assert worker._model_manager.unload_calls == 0
+
+    def test_skips_when_model_not_loaded(self, monkeypatch) -> None:
+        """An unloaded model is not auto-unloaded again."""
+        worker = _make_worker(
+            auto_unload=True,
+            timeout=600,
+            status=ModelStatus.UNLOADED,
+        )
+        fake_now = _freeze_clock(monkeypatch, 1000.0)
+        worker._last_request_time = fake_now["value"] - 99999
+
+        worker._check_inactivity()
+
+        assert worker._model_manager.unload_calls == 0
+
+
+class TestActivityTimestamp:
+    """Every request that reaches the worker refreshes the idle clock."""
+
+    def test_on_llm_request_signal_refreshes_timestamp(
+        self, monkeypatch
+    ) -> None:
+        """The signal handler resets ``_last_request_time`` per request."""
+        fake_now = _freeze_clock(monkeypatch, 1000.0)
+        worker = LLMGenerateWorker()
+
+        worker.on_llm_request_signal({"request_data": {}})
+
+        assert worker._last_request_time == fake_now["value"]
+
+    def test_update_activity_timestamp_sets_now(self, monkeypatch) -> None:
+        """``_update_activity_timestamp`` records the current time."""
+        fake_now = _freeze_clock(monkeypatch, 1234.0)
+        worker = LLMGenerateWorker()
+        worker._last_request_time = None
+
+        worker._update_activity_timestamp()
+
+        assert worker._last_request_time == fake_now["value"]
+
+
+class TestTimerStart:
+    """The inactivity timer starts when enabled and logs the real timeout."""
+
+    def test_start_inactivity_timer_logs_configured_timeout(
+        self, monkeypatch
+    ) -> None:
+        """The log message reports the configured (not hardcoded) timeout."""
+        monkeypatch.setenv(_ENV_AUTO_UNLOAD, "1")
+        monkeypatch.setenv(_ENV_TIMEOUT, "600")
+        worker = LLMGenerateWorker()
+        logger = Mock()
+        worker.logger = logger
+
+        worker._start_inactivity_timer()
+        try:
+            assert isinstance(worker._inactivity_timer, QTimer)
+            logged = " ".join(
+                str(call) for call in logger.info.call_args_list
+            )
+            assert "10 minute timeout" in logged
+        finally:
+            if worker._inactivity_timer is not None:
+                worker._inactivity_timer.stop()
+
+    def test_start_worker_thread_starts_timer_when_enabled(
+        self, monkeypatch
+    ) -> None:
+        """The daemon start hook turns the timer on with auto-unload."""
+        monkeypatch.setenv(_ENV_AUTO_UNLOAD, "1")
+        worker = LLMGenerateWorker()
+        worker._load_settings = Mock(
+            return_value=SimpleNamespace(llm_enabled=False)
+        )
+        worker._start_inactivity_timer = Mock(
+            wraps=worker._start_inactivity_timer
+        )
+
+        worker.start_worker_thread()
+
+        worker._start_inactivity_timer.assert_called_once()
+
+    def test_start_worker_thread_skips_timer_when_disabled(
+        self, monkeypatch
+    ) -> None:
+        """Auto-unload off leaves the timer unstarted."""
+        monkeypatch.delenv(_ENV_AUTO_UNLOAD, raising=False)
+        worker = LLMGenerateWorker()
+        worker._load_settings = Mock(
+            return_value=SimpleNamespace(llm_enabled=False)
+        )
+
+        worker.start_worker_thread()
+
+        assert worker._inactivity_timer is None

--- a/services/tests/test_llm_generate_worker_idle_unload.py
+++ b/services/tests/test_llm_generate_worker_idle_unload.py
@@ -21,6 +21,7 @@ from airunner_services.workers.llm_generate_worker import (
     LLMGenerateWorker,
     time as worker_time,
 )
+from airunner_services.workers.worker import QueueType
 
 _ENV_AUTO_UNLOAD = "AIRUNNER_LLM_AUTO_UNLOAD"
 _ENV_TIMEOUT = "AIRUNNER_LLM_INACTIVITY_TIMEOUT_SECONDS"
@@ -241,3 +242,84 @@ class TestTimerStart:
         worker.start_worker_thread()
 
         assert worker._inactivity_timer is None
+
+
+class TestLifecycleWiring:
+    """The timer starts through the real daemon bootstrap paths.
+
+    Regression coverage for issue #128 rework: no production code calls
+    ``start_worker_thread()`` - ``create_worker`` connects
+    ``worker_thread.started`` directly to ``worker.run()``, so the timer must
+    start from the worker's own ``run()`` and from
+    ``CoreLifecycleService.initialize()``.
+    """
+
+    def test_run_starts_inactivity_timer_when_enabled(self, monkeypatch) -> None:
+        """``run()`` (the real daemon entry point) starts the timer."""
+        monkeypatch.setenv(_ENV_AUTO_UNLOAD, "1")
+        worker = LLMGenerateWorker()
+        worker.queue_type = QueueType.NONE  # keep run() from looping forever
+
+        worker.run()
+
+        try:
+            assert isinstance(worker._inactivity_timer, QTimer)
+        finally:
+            if worker._inactivity_timer is not None:
+                worker._inactivity_timer.stop()
+
+    def test_run_skips_inactivity_timer_when_disabled(self, monkeypatch) -> None:
+        """``run()`` leaves the timer unstarted when auto-unload is off."""
+        monkeypatch.delenv(_ENV_AUTO_UNLOAD, raising=False)
+        worker = LLMGenerateWorker()
+        worker.queue_type = QueueType.NONE
+
+        worker.run()
+
+        assert worker._inactivity_timer is None
+
+    def test_start_inactivity_timer_is_idempotent(self, monkeypatch) -> None:
+        """A second start keeps the existing timer instead of stacking."""
+        monkeypatch.setenv(_ENV_AUTO_UNLOAD, "1")
+        worker = LLMGenerateWorker()
+
+        worker._start_inactivity_timer()
+        first_timer = worker._inactivity_timer
+        try:
+            worker._start_inactivity_timer()
+            assert worker._inactivity_timer is first_timer
+        finally:
+            if first_timer is not None:
+                first_timer.stop()
+
+    def test_create_worker_bootstrap_starts_inactivity_timer(
+        self, monkeypatch
+    ) -> None:
+        """The real ``create_worker`` bootstrap starts the timer on the worker."""
+        from airunner_services.utils.application.create_worker import (
+            create_worker,
+        )
+
+        monkeypatch.setenv(_ENV_AUTO_UNLOAD, "1")
+        worker = create_worker(LLMGenerateWorker)
+        try:
+            assert isinstance(worker._inactivity_timer, QTimer)
+        finally:
+            worker._inactivity_timer.stop()
+
+    def test_lifecycle_service_initialize_starts_inactivity_timer(
+        self, monkeypatch
+    ) -> None:
+        """The headless daemon lifecycle starts the timer on its worker."""
+        from airunner_services.lifecycle_service import CoreLifecycleService
+
+        monkeypatch.setenv(_ENV_AUTO_UNLOAD, "1")
+        lifecycle = CoreLifecycleService(signal_source=SimpleNamespace())
+        lifecycle.initialize()
+        worker = lifecycle.llm_generate_worker
+        try:
+            assert worker is not None
+            assert isinstance(worker._inactivity_timer, QTimer)
+        finally:
+            if worker is not None and worker._inactivity_timer is not None:
+                worker._inactivity_timer.stop()


### PR DESCRIPTION
## Summary

Makes the LLM idle auto-unload in the service-owned `LLMGenerateWorker` env-configurable so the LAN daemon deployment can unload the local GGUF model after 10 minutes of inactivity.

### Changes

**`services/src/airunner_services/workers/llm_generate_worker.py`**
- `_auto_unload_enabled` (was `False`) now reads `os.environ.get("AIRUNNER_LLM_AUTO_UNLOAD", "0") == "1"` — default stays OFF so existing deployments behave identically.
- `_inactivity_timeout` (was `300`) now reads `int(os.environ.get("AIRUNNER_LLM_INACTIVITY_TIMEOUT_SECONDS", "300"))` — default stays 300; the daemon deployment sets 600 (10 min).
- `_start_inactivity_timer()` log now reports the actual configured timeout instead of the hardcoded "5 minute timeout"; the start is idempotent.
- **Wiring (rework):** the timer is now started from `LLMGenerateWorker.run()` — the entry point `create_worker` actually connects to `worker_thread.started` in both the service and GUI bootstrap paths. `start_worker_thread()` is kept as a legacy compatibility hook (no production code calls it), and both `run()` and the compatibility hook call the idempotent `_start_inactivity_timer()`. The timer is stopped on `stop()` and on the quit-application handler.
- `_update_activity_timestamp()` refreshes the clock on every request that reaches the worker (`on_llm_request_signal`).

**`services/tests/test_llm_generate_worker_idle_unload.py`** (new)
- Env parsing: unset -> off / 300; `AIRUNNER_LLM_AUTO_UNLOAD=1` + `AIRUNNER_LLM_INACTIVITY_TIMEOUT_SECONDS=600` -> on / 600.
- Inactivity check fires `unload_llm()` exactly at the boundary (`inactive_time >= timeout`) and not before.
- Activity timestamp refresh per request + timer start/log verification.
- **Bootstrap-path regression tests (rework):** `run()` starts the timer when enabled and skips when disabled; `_start_inactivity_timer()` is idempotent; the real `create_worker()` bootstrap starts the timer; `CoreLifecycleService.initialize()` (the headless daemon lifecycle) starts the timer.

### Request-path trace (activity timestamp refresh)

Legacy compat routes (`legacy_openai_compat.py`, `legacy_ollama_compat.py`, `legacy_native_compat.py`) all call `app.llm.send_request(...)` -> `LLMAPIService.send_request` (via `LLMRequestDispatchMixin`) -> emits `LLM_TEXT_GENERATE_REQUEST_SIGNAL` -> worker `on_llm_request_signal` -> `_update_activity_timestamp()` — so the 10-minute clock resets on any request that reaches the worker. The timestamp was already refreshed per request; no additional call was needed.

### Verification

- Non-functional services unit suite: `139 passed` (was 134 before this rework; +5 new bootstrap-path tests), 46 deselected (functional/daemon-spawning suites — they boot real daemons and need GPU/models, not runnable in the sandbox).
- Worker idle-unload test file: `18 passed`.
- Boot probe (reproducing the reviewer's failing scenario): with `AIRUNNER_LLM_AUTO_UNLOAD=1`/`600`, both `create_worker(LLMGenerateWorker)` and `CoreLifecycleService.initialize()` leave `worker._inactivity_timer` as a running `QTimer` and log "10 minute timeout".

Note: the venv's editable installs point at the main checkout, so tests are run with `PYTHONPATH` pointing at this worktree's `services/src`, `shared`, and `native/src` to exercise the worktree code.