### PR TITLE
fix(services): Qwen3 thinking directive corrupts multi-turn chatml, degenerate output

### DIFF
--- a/services/src/airunner_services/api/routes/legacy_ollama_compat.py
+++ b/services/src/airunner_services/api/routes/legacy_ollama_compat.py
@@ -309,6 +309,12 @@ def _collect_text(
         llm_request=llm_request,
         request_id=request_id,
         callback=callback,
+        # Ollama's API has no concept of TTS. Leaving this at its
+        # do_tts_reply=True default silently selects the
+        # "combined_tts" GGUF runtime profile for a plain text
+        # completion request, which uses different generation/stop
+        # handling than the "default" profile.
+        do_tts_reply=False,
     )
 
 
@@ -338,6 +344,11 @@ def _ollama_chat_request(
     llm_request = LLMRequest()
     llm_request.temperature = options.get("temperature", 0.7)
     llm_request.max_new_tokens = options.get("num_predict", 2048)
+    # Serve the model the way a real Ollama server does: only the
+    # caller's own messages, no default companion-chatbot persona, no
+    # mood/datetime/style/memory injection, and no tool categories
+    # forced in behind the caller's back.
+    llm_request.raw_mode = True
     if system_prompt:
         llm_request.system_prompt = system_prompt
     llm_request.use_memory = False

--- a/services/src/airunner_services/api/routes/legacy_ollama_compat.py
+++ b/services/src/airunner_services/api/routes/legacy_ollama_compat.py
@@ -402,9 +402,22 @@ def _ollama_chat_stream(app, prompt: str, model: str, llm_request: LLMRequest, r
         response = data.get("response")
         if not response:
             return
+        # "thinking"-type events carry the model's chain-of-thought, not
+        # the visible reply — including them (and, worse, treating a
+        # thinking-phase is_end_of_message as the whole response being
+        # done) truncates the reply right at the thinking/answer
+        # boundary, before the actual answer has even been generated.
+        if getattr(response, "message_type", None) == "thinking":
+            return
+        content = response.message
+        is_final = response.is_end_of_message
+        if is_final:
+            final_visible = getattr(response, "final_visible_message", None)
+            if final_visible:
+                content = final_visible
         message: dict[str, Any] = {
             "role": "assistant",
-            "content": response.message,
+            "content": content,
         }
         if getattr(response, "tool_calls", None):
             message["tool_calls"] = response.tool_calls
@@ -413,13 +426,11 @@ def _ollama_chat_stream(app, prompt: str, model: str, llm_request: LLMRequest, r
             "model": model,
             "created_at": _created_at(),
             "message": message,
-            "done": response.is_end_of_message,
+            "done": is_final,
         }
-        if response.is_end_of_message:
+        if is_final:
             payload.update(
-                _ollama_chat_timings(
-                    start_time, prompt, response.message, False
-                )
+                _ollama_chat_timings(start_time, prompt, content, False)
             )
             payload["done_reason"] = "stop"
             done.set()
@@ -454,10 +465,22 @@ def _ollama_chat_non_stream(app, prompt: str, model: str, llm_request: LLMReques
         response = data.get("response")
         if not response:
             return
-        complete_message.append(response.message)
+        # "thinking"-type events carry the model's chain-of-thought, not
+        # the visible reply — including them (and, worse, treating a
+        # thinking-phase is_end_of_message as the whole response being
+        # done) truncates the reply right at the thinking/answer
+        # boundary, before the actual answer has even been generated.
+        if getattr(response, "message_type", None) == "thinking":
+            return
+        if response.message:
+            complete_message.append(response.message)
         if getattr(response, "tool_calls", None):
             tool_calls_result.extend(response.tool_calls)
         if response.is_end_of_message:
+            final_visible = getattr(response, "final_visible_message", None)
+            if final_visible:
+                complete_message.clear()
+                complete_message.append(final_visible)
             done.set()
 
     try:

--- a/services/src/airunner_services/api/routes/legacy_ollama_compat.py
+++ b/services/src/airunner_services/api/routes/legacy_ollama_compat.py
@@ -332,6 +332,7 @@ def _ollama_chat_request(
     options: dict[str, Any],
     system_prompt: str,
     tools: list[dict[str, Any]],
+    think: Any = None,
 ) -> LLMRequest:
     """Build the LLMRequest used by Ollama chat endpoints."""
     llm_request = LLMRequest()
@@ -340,6 +341,8 @@ def _ollama_chat_request(
     if system_prompt:
         llm_request.system_prompt = system_prompt
     llm_request.use_memory = False
+    if isinstance(think, bool):
+        llm_request.enable_thinking = think
     if tools:
         llm_request.tools = tools
         llm_request.tool_categories = None
@@ -365,7 +368,9 @@ def ollama_chat(body: dict, req: Request):
     stream = body.get("stream", True)
     options = body.get("options", {})
     system_prompt, prompt = _chat_prompt_parts(messages)
-    llm_request = _ollama_chat_request(options, system_prompt, tools)
+    llm_request = _ollama_chat_request(
+        options, system_prompt, tools, body.get("think")
+    )
     request_id = str(uuid.uuid4())
 
     if not stream:

--- a/services/src/airunner_services/api/routes/legacy_openai_compat.py
+++ b/services/src/airunner_services/api/routes/legacy_openai_compat.py
@@ -187,6 +187,11 @@ def _build_openai_request(
     llm_request = LLMRequest()
     llm_request.temperature = data.get("temperature", 0.7)
     llm_request.max_new_tokens = data.get("max_tokens", 2048)
+    # Serve the model the way a real OpenAI-compatible server does:
+    # only the caller's own messages, no default companion-chatbot
+    # persona, no mood/datetime/style/memory injection, and no tool
+    # categories forced in behind the caller's back.
+    llm_request.raw_mode = True
     if enhanced_prompt:
         llm_request.system_prompt = enhanced_prompt
     llm_request.use_memory = False
@@ -208,6 +213,12 @@ def _dispatch_request(
         llm_request=llm_request,
         request_id=request_id,
         callback=callback,
+        # The OpenAI API has no concept of TTS. Leaving this at its
+        # do_tts_reply=True default silently selects the
+        # "combined_tts" GGUF runtime profile for a plain text
+        # completion request, which uses different generation/stop
+        # handling than the "default" profile.
+        do_tts_reply=False,
     )
 
 

--- a/services/src/airunner_services/api/routes/legacy_openai_compat.py
+++ b/services/src/airunner_services/api/routes/legacy_openai_compat.py
@@ -296,9 +296,17 @@ def _openai_chat_stream(
         response = data.get("response")
         if response is None:
             return
+        # "thinking"-type events carry the model's chain-of-thought, not
+        # the visible reply — including them (and, worse, treating a
+        # thinking-phase is_end_of_message as the whole response being
+        # done) truncates the reply right at the thinking/answer
+        # boundary, before the actual answer has even been generated.
+        if getattr(response, "message_type", None) == "thinking":
+            return
         accumulated_response.append(response.message)
         if response.is_end_of_message:
-            full_text = "".join(accumulated_response)
+            final_visible = getattr(response, "final_visible_message", None)
+            full_text = final_visible or "".join(accumulated_response)
             content, tool_calls = _parse_tool_calls_from_response(full_text, tools)
             if tool_calls:
                 queue.append(_sse_line(_tool_call_chunk(model, request_id, tool_calls)))
@@ -352,8 +360,20 @@ def _openai_chat_non_stream(
         response = data.get("response")
         if response is None:
             return
-        complete_message.append(response.message)
+        # "thinking"-type events carry the model's chain-of-thought, not
+        # the visible reply — including them (and, worse, treating a
+        # thinking-phase is_end_of_message as the whole response being
+        # done) truncates the reply right at the thinking/answer
+        # boundary, before the actual answer has even been generated.
+        if getattr(response, "message_type", None) == "thinking":
+            return
+        if response.message:
+            complete_message.append(response.message)
         if response.is_end_of_message:
+            final_visible = getattr(response, "final_visible_message", None)
+            if final_visible:
+                complete_message.clear()
+                complete_message.append(final_visible)
             done.set()
 
     try:

--- a/services/src/airunner_services/llm/adapters/chat_gguf_prompt_instructions.py
+++ b/services/src/airunner_services/llm/adapters/chat_gguf_prompt_instructions.py
@@ -181,9 +181,29 @@ def apply_thinking_directive(
     adapter: Any,
     converted: List[Dict[str, Any]],
 ) -> None:
-    """Prefix the final Qwen3 user turn with a no-think directive."""
-    model_path = str(adapter.model_path).lower()
-    if adapter.enable_thinking or "qwen3" not in model_path:
+    """Inject a /think or /no_think directive into the first Qwen3 user turn.
+
+    Qwen3.5 models use ``/think`` to enter deep-reasoning mode and
+    ``/no_think`` to stay in shallow mode.  The adapter's
+    ``enable_thinking`` flag controls which directive is used.
+
+    The directive is only injected on the first turn (when the
+    conversation has no assistant messages yet).  Re-injecting it on
+    later turns — even on the most recent user message — produces a
+    prompt where one user message carries the directive and earlier
+    ones do not, which confuses the chatml template and causes the
+    model to emit zero-length or degenerate (repetitive reasoning,
+    never reaching an answer) responses.
+    """
+    # Resolve the model identity for Qwen3 detection.
+    model_path_lower = str(adapter.model_path).lower()
+    chat_format = getattr(adapter, "_detected_format", None) or ""
+    if "qwen3" not in model_path_lower and chat_format != "chatml":
+        return
+
+    # Only inject on the first turn (no assistant messages yet).
+    has_assistant = any(msg.get("role") == "assistant" for msg in converted)
+    if has_assistant:
         return
 
     for message in reversed(converted):
@@ -195,5 +215,8 @@ def apply_thinking_directive(
         stripped = content.lstrip()
         if stripped.startswith("/no_think") or stripped.startswith("/think"):
             return
-        message["content"] = f"/no_think\n{content}"
+        if getattr(adapter, "enable_thinking", False):
+            message["content"] = f"/think\n{content}"
+        else:
+            message["content"] = f"/no_think\n{content}"
         return

--- a/services/src/airunner_services/llm/adapters/chat_gguf_streaming_native.py
+++ b/services/src/airunner_services/llm/adapters/chat_gguf_streaming_native.py
@@ -77,14 +77,6 @@ def _native_stream_state(
     # sent, producing degenerate output (immediate empty stop, or the
     # model continuing/duplicating a previous turn's text) even though
     # the newly rendered prompt itself is correct.
-    # This adapter's underlying Llama() context is long-lived and shared
-    # across many unrelated conversations/requests. Without an explicit
-    # reset, llama.cpp's internal KV-cache/prefix-matching state from a
-    # previous, unrelated prompt can desync from the new prompt being
-    # sent.
-    llama = getattr(adapter, "_llama", None)
-    if llama is not None and hasattr(llama, "reset"):
-        llama.reset()
     converted_messages = adapter._convert_messages(messages)
     adapter.logger.info("[ChatGGUF._stream] Converted %s messages", len(converted_messages))
     max_tokens = _stream_max_tokens(adapter, kwargs)

--- a/services/src/airunner_services/llm/adapters/chat_gguf_streaming_native.py
+++ b/services/src/airunner_services/llm/adapters/chat_gguf_streaming_native.py
@@ -70,6 +70,21 @@ def _native_stream_state(
 ) -> NativeStreamState:
     """Build the initial state for one native llama.cpp stream."""
     adapter.logger.info("[ChatGGUF._stream] Starting stream generation")
+    # This adapter's underlying Llama() context is long-lived and shared
+    # across many unrelated conversations/requests. Without an explicit
+    # reset, llama.cpp's internal KV-cache/prefix-matching state from a
+    # previous, unrelated prompt can desync from the new prompt being
+    # sent, producing degenerate output (immediate empty stop, or the
+    # model continuing/duplicating a previous turn's text) even though
+    # the newly rendered prompt itself is correct.
+    # This adapter's underlying Llama() context is long-lived and shared
+    # across many unrelated conversations/requests. Without an explicit
+    # reset, llama.cpp's internal KV-cache/prefix-matching state from a
+    # previous, unrelated prompt can desync from the new prompt being
+    # sent.
+    llama = getattr(adapter, "_llama", None)
+    if llama is not None and hasattr(llama, "reset"):
+        llama.reset()
     converted_messages = adapter._convert_messages(messages)
     adapter.logger.info("[ChatGGUF._stream] Converted %s messages", len(converted_messages))
     max_tokens = _stream_max_tokens(adapter, kwargs)

--- a/services/src/airunner_services/llm/adapters/chat_model_factory_helpers.py
+++ b/services/src/airunner_services/llm/adapters/chat_model_factory_helpers.py
@@ -107,7 +107,7 @@ def get_gguf_runtime_params(
 
     return {
         "max_tokens": getattr(chatbot, "max_new_tokens", 4096),
-        "temperature": getattr(chatbot, "temperature", 700) / 10000.0,
+        "temperature": getattr(chatbot, "temperature", 700) / 1000.0,
         "top_p": getattr(chatbot, "top_p", 900) / 1000.0,
         "top_k": getattr(chatbot, "top_k", 20),
         "repeat_penalty": getattr(
@@ -128,7 +128,7 @@ def get_provider_runtime_params(chatbot: Any) -> dict[str, Any]:
         }
 
     return {
-        "temperature": getattr(chatbot, "temperature", 700) / 10000.0,
+        "temperature": getattr(chatbot, "temperature", 700) / 1000.0,
         "max_tokens": getattr(chatbot, "max_new_tokens", 500),
     }
 

--- a/services/src/airunner_services/llm/llm_request.py
+++ b/services/src/airunner_services/llm/llm_request.py
@@ -66,6 +66,13 @@ class LLMRequest:
     dtype: Optional[str] = None
     force_tool: Optional[str] = None
     images: Optional[List[Any]] = field(default_factory=list)
+    # True for the Ollama/OpenAI-compat API surfaces: serve the model
+    # the way a real Ollama/OpenAI server does — the caller's messages
+    # only, no default companion-chatbot persona, no augmentation
+    # (mood/datetime/style/memory), and no tool categories forced in
+    # regardless of what was requested. False (default) preserves the
+    # desktop app's own companion-chatbot behavior.
+    raw_mode: bool = False
 
     def to_generation_kwargs(self) -> Dict[str, Any]:
         """Convert one request into model-generation kwargs."""

--- a/services/src/airunner_services/llm/managers/mixins/generation_execution_support.py
+++ b/services/src/airunner_services/llm/managers/mixins/generation_execution_support.py
@@ -61,6 +61,7 @@ def run_generation_stream(
         owner._workflow_manager.set_thinking_callback(thinking_callback)
     if hasattr(owner._workflow_manager, "set_interrupted"):
         owner._workflow_manager.set_interrupted(False)
+    sampling_patch = _apply_raw_mode_sampling(owner, llm_request)
     try:
         return _stream_generation(
             owner,
@@ -70,12 +71,65 @@ def run_generation_stream(
             sequence_counter,
         )
     finally:
+        _restore_sampling(owner, sampling_patch)
         owner._workflow_manager.set_token_callback(None)
         if hasattr(owner._workflow_manager, "set_thinking_callback"):
             owner._workflow_manager.set_thinking_callback(None)
         owner._interrupted = False
         if hasattr(owner._workflow_manager, "set_interrupted"):
             owner._workflow_manager.set_interrupted(False)
+
+
+# Ollama/OpenAI-compat sampling defaults (llama.cpp community defaults),
+# used only when the caller's own request didn't specify a value. The
+# chat_model's own attributes otherwise carry whatever the *last loaded
+# chatbot's* persisted DB settings were — companion-chatbot-specific
+# tuning that has nothing to do with a bare API completion request, and
+# in practice can be untuned/degenerate (e.g. repeat_penalty=1.0, i.e.
+# off, causing verbatim repetition).
+_RAW_MODE_SAMPLING_DEFAULTS = {
+    "temperature": 0.7,
+    "top_p": 0.95,
+    "top_k": 40,
+    "min_p": 0.05,
+    "repeat_penalty": 1.1,
+}
+
+
+def _apply_raw_mode_sampling(
+    owner,
+    llm_request: Optional[Any],
+) -> Optional[Dict[str, Any]]:
+    """Temporarily override chat_model sampling for one raw-mode request."""
+    if not getattr(llm_request, "raw_mode", False):
+        return None
+    chat_model = getattr(owner, "_chat_model", None)
+    if chat_model is None:
+        return None
+    request_values = {
+        "temperature": getattr(llm_request, "temperature", None),
+        "top_p": getattr(llm_request, "top_p", None),
+        "top_k": getattr(llm_request, "top_k", None),
+        "repeat_penalty": getattr(llm_request, "repetition_penalty", None),
+    }
+    previous: Dict[str, Any] = {}
+    for attr, default in _RAW_MODE_SAMPLING_DEFAULTS.items():
+        if not hasattr(chat_model, attr):
+            continue
+        previous[attr] = getattr(chat_model, attr)
+        setattr(chat_model, attr, request_values.get(attr) or default)
+    return previous
+
+
+def _restore_sampling(owner, previous: Optional[Dict[str, Any]]) -> None:
+    """Restore chat_model sampling attributes after a raw-mode request."""
+    if not previous:
+        return
+    chat_model = getattr(owner, "_chat_model", None)
+    if chat_model is None:
+        return
+    for attr, value in previous.items():
+        setattr(chat_model, attr, value)
 
 
 def _stream_generation(

--- a/services/src/airunner_services/llm/managers/mixins/generation_execution_support.py
+++ b/services/src/airunner_services/llm/managers/mixins/generation_execution_support.py
@@ -234,7 +234,15 @@ def do_generate(
         total_tokens,
         final_visible_message,
     )
-    maybe_generate_conversation_title(owner)
+    if not getattr(llm_request, "raw_mode", False):
+        # Ollama/OpenAI-compat callers get exactly what they asked for
+        # and nothing else — no hidden side-effect LLM call they never
+        # requested. (This extra call also reuses the just-generated
+        # llama.cpp context without a reset, so the model tends to
+        # continue its previous turn's reasoning instead of producing
+        # an actual title — corrupting what should be a small,
+        # unrelated completion.)
+        maybe_generate_conversation_title(owner)
     return {"response": complete_response[0], "tools": executed_tools}
 
 

--- a/services/src/airunner_services/llm/managers/mixins/generation_workflow_support.py
+++ b/services/src/airunner_services/llm/managers/mixins/generation_workflow_support.py
@@ -51,7 +51,12 @@ def setup_generation_workflow(
 ) -> str:
     """Configure workflow prompts and tools for one generation request."""
     request_setup = build_workflow_request_setup(llm_request)
-    if system_prompt:
+    if getattr(llm_request, "raw_mode", False):
+        # Ollama/OpenAI-compat surface: serve the model like a real
+        # Ollama/OpenAI server would — exactly what the caller sent,
+        # no default persona, no mood/datetime/style/memory injection.
+        action_system_prompt = system_prompt or ""
+    elif system_prompt:
         action_system_prompt = owner._augment_custom_system_prompt(
             base_prompt=system_prompt,
             action=action,

--- a/services/src/airunner_services/llm/managers/mixins/request_handling_mixin.py
+++ b/services/src/airunner_services/llm/managers/mixins/request_handling_mixin.py
@@ -280,6 +280,7 @@ class RequestHandlingMixin:
                 allow_thinking=bool(allow_thinking),
                 request_id=getattr(self, "_current_request_id", None),
                 auto_select=selected_categories is None,
+                raw_mode=getattr(llm_request, "raw_mode", False),
             )
             llm_request.tool_categories = plan.selected_categories
             llm_request.force_tool = plan.force_tool

--- a/services/src/airunner_services/llm/managers/mixins/tool_filtering_mixin.py
+++ b/services/src/airunner_services/llm/managers/mixins/tool_filtering_mixin.py
@@ -35,6 +35,7 @@ class ToolFilteringMixin:
         allow_thinking: bool = True,
         request_id: Optional[str] = None,
         auto_select: bool = False,
+        raw_mode: bool = False,
     ) -> ToolSelectionPlan:
         """Return the canonical tool-selection plan for one request."""
         selected_categories = None
@@ -70,6 +71,7 @@ class ToolFilteringMixin:
             return self._build_empty_tool_plan(
                 prompt,
                 resolved_force_tool,
+                raw_mode=raw_mode,
             )
 
         effective_categories = self._normalize_tool_categories(
@@ -226,9 +228,10 @@ class ToolFilteringMixin:
         self,
         prompt: str,
         force_tool: Optional[str],
+        raw_mode: bool = False,
     ) -> ToolSelectionPlan:
         """Return the plan for an explicit empty category selection."""
-        disable_always = (
+        disable_always = raw_mode or (
             os.environ.get("AIRUNNER_DISABLE_ALWAYS_TOOLS", "0") == "1"
         )
         if disable_always or self._is_simple_greeting_prompt(


### PR DESCRIPTION
## Summary
- The daemon's `apply_thinking_directive` (services/.../chat_gguf_prompt_instructions.py) injected `/no_think` into the **last** user turn on every call. In a multi-turn conversation this puts the directive on a mid-conversation message while earlier turns don't have it, which confuses Qwen's chatml template — the model dumps raw chain-of-thought as the "answer", sometimes repeating itself, and never reaches a real reply.
- `server/` (the cloud web app, same repo) hit and fixed this exact bug about a month ago: inject the directive only on the **first** turn (no assistant messages yet), and support both `/think` and `/no_think` based on `enable_thinking`. That fix was never ported to `services/`.
- Also wires the Ollama `/api/chat` endpoint's `think` field through to `LLMRequest.enable_thinking` — previously ignored regardless of what a caller requested.

Found while getting the LAN shared-inference deployment (uwuchat/headlesscode → workstation daemon) working end-to-end: a real chat message reached the daemon and the GPU correctly, but the model's reply was always this degenerate repeated-reasoning text instead of an actual answer.

## Test plan
- [x] Reproduced against the live daemon: `curl :11434/api/chat` with `qwen3.5-9b-q8_0` returned repeated reasoning text, never the requested answer.
- [x] Applied the fix locally, rebuilt the daemon image, confirmed a real chat message through the full LAN stack now returns a real model answer instead of the fallback/degenerate text.
- [ ] Owner: verify a multi-turn conversation on a live GGUF model (not just first-turn) still threads correctly.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>