### PR TITLE
fix(daemon_client): cancel_runtime raises TypeError on every call

### DIFF
--- a/services/src/airunner_services/daemon_client/gui_daemon_client.py
+++ b/services/src/airunner_services/daemon_client/gui_daemon_client.py
@@ -267,7 +267,9 @@ class GuiDaemonClient(GuiBridgeMixin):
         provider: str = "local",
         deployment_mode: str = "default",
         request_id: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         auto_start: bool = False,
+        timeout_seconds: Optional[float] = None,
     ) -> Dict[str, Any]:
         """Cancel one runtime request through the daemon control API."""
         return self._runtime_action(
@@ -276,7 +278,9 @@ class GuiDaemonClient(GuiBridgeMixin):
             provider=provider,
             deployment_mode=deployment_mode,
             request_id=request_id,
+            metadata=metadata,
             auto_start=auto_start,
+            timeout_seconds=timeout_seconds,
         )
 
     def synthesize_tts(

--- a/services/tests/test_gui_daemon_client_runtime_actions.py
+++ b/services/tests/test_gui_daemon_client_runtime_actions.py
@@ -1,0 +1,64 @@
+"""Unit tests for ``GuiDaemonClient`` runtime control actions.
+
+``_runtime_action`` declares ``metadata`` and ``timeout_seconds`` as
+keyword-only arguments with no defaults, so every public wrapper has to
+forward them.  ``cancel_runtime`` did not, which made it raise
+``TypeError`` on every call (issue: TTS interrupt path).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from airunner_services.daemon_client.gui_daemon_client import GuiDaemonClient
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> GuiDaemonClient:
+    instance = GuiDaemonClient.__new__(GuiDaemonClient)
+    calls: list[tuple[tuple, dict]] = []
+
+    def _request(*args, **kwargs):
+        calls.append((args, kwargs))
+        return SimpleNamespace(json=lambda: {"status": "ok"})
+
+    monkeypatch.setattr(instance, "_request", _request, raising=False)
+    instance.recorded_calls = calls
+    return instance
+
+
+@pytest.mark.parametrize(
+    "action", ["load_runtime", "unload_runtime", "cancel_runtime"]
+)
+def test_runtime_wrappers_forward_every_required_argument(
+    client: GuiDaemonClient, action: str
+) -> None:
+    """Each wrapper must satisfy ``_runtime_action``'s keyword-only args."""
+    result = getattr(client, action)(
+        "tts",
+        deployment_mode="sidecar",
+        request_id="req-1",
+    )
+
+    assert result == {"status": "ok"}
+    assert len(client.recorded_calls) == 1
+
+
+def test_cancel_runtime_passes_metadata_and_timeout(
+    client: GuiDaemonClient,
+) -> None:
+    """Explicit metadata/timeout reach the request body like the siblings."""
+    client.cancel_runtime(
+        "tts",
+        deployment_mode="sidecar",
+        request_id="req-1",
+        metadata={"reason": "interrupt"},
+        timeout_seconds=5.0,
+    )
+
+    args, kwargs = client.recorded_calls[0]
+    assert args == ("POST", "/api/v1/daemon/runtimes/tts/cancel")
+    assert kwargs["json_payload"]["metadata"] == {"reason": "interrupt"}
+    assert kwargs["timeout_seconds"] == 5.0


### PR DESCRIPTION
`GuiDaemonClient.cancel_runtime` raises on every call:

```
TypeError: GuiDaemonClient._runtime_action() missing 2 required keyword-only
arguments: 'metadata' and 'timeout_seconds'
```

`_runtime_action` (`gui_daemon_client.py:1065`) declares both as keyword-only **without defaults**, so every wrapper has to forward them:

```python
def _runtime_action(
    self, runtime_name: str, action: str, *,
    provider: str,
    deployment_mode: str,
    request_id: Optional[str],
    metadata: Optional[Dict[str, Any]],      # <- required
    auto_start: bool,
    timeout_seconds: Optional[float],        # <- required
) -> Dict[str, Any]:
```

| Wrapper | `metadata` | `timeout_seconds` |
| --- | --- | --- |
| `load_runtime` (`:644`) | ✅ | ✅ |
| `unload_runtime` (`:667`) | ✅ | ✅ |
| `cancel_runtime` (`:263`) | ❌ | ❌ |

`cancel_runtime` is the only one of the three that misses them.

## Impact

It is on a live path, not dead code. The TTS interrupt handler calls it:

```python
# src/airunner/components/tts/workers/tts_generator_worker.py:227
try:
    client.cancel_runtime(
        "tts", deployment_mode="sidecar",
        request_id=request_id, auto_start=False,
    )
except RuntimeError:
    pass
```

The `except RuntimeError` does not catch a `TypeError`, so interrupting TTS propagates the error instead of cancelling the request. `services/src/airunner_services/workers/tts_generator_worker.py:452` has the same call.

## Fix

Give `cancel_runtime` the same two keyword-only parameters as its siblings and forward them. `auto_start` keeps its existing `False` default — cancelling a request should not start the runtime.

## Verification

Extracted the three real methods from the file with `ast` (not hand-copied), bound them onto a stub whose `_request` records the call, and called each — `load_runtime` as the control:

**Before**
```
  load_runtime  (sibling)  -> OK
  cancel_runtime           -> TypeError: _runtime_action() missing 2 required
                              keyword-only arguments: 'metadata' and 'timeout_seconds'
```

**After**
```
  load_runtime  (sibling)  -> OK
  cancel_runtime           -> OK
```

Added `services/tests/test_gui_daemon_client_runtime_actions.py`, which parametrizes over all three wrappers so a future wrapper missing an argument fails too, and asserts that an explicit `metadata`/`timeout_seconds` actually reaches the request:

```
$ python -m pytest services/tests/test_gui_daemon_client_runtime_actions.py -q
4 passed
```

On `master` the same file fails with the two `TypeError`s above.

`black --line-length 79` (the setting in `pyproject.toml`) leaves both changed files unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
