### PR TITLE
fix(quantization): fall back to INT2 when VRAM is below the INT4 budget

### DIFF
--- a/src/airunner/components/model_management/quantization_strategy.py
+++ b/src/airunner/components/model_management/quantization_strategy.py
@@ -68,7 +68,7 @@ class QuantizationStrategy:
             )
         else:
             return self._get_config_for_level(
-                QuantizationLevel.INT4, model_size_gb
+                QuantizationLevel.INT2, model_size_gb
             )
 
     def _get_config_for_level(


### PR DESCRIPTION
### Problem

`QuantizationStrategy._auto_select_quantization` ends with an `else` branch that is
byte-for-byte the same as the `elif` above it:

```python
elif vram_gb >= model_size_gb * 0.5:
    return self._get_config_for_level(QuantizationLevel.INT4, model_size_gb)
else:
    return self._get_config_for_level(QuantizationLevel.INT4, model_size_gb)
```

So the last rung of the ladder is a no-op, and the fallback returns the *4-bit*
config in exactly the case where 4-bit is known not to fit: the `else` is reached
only when `vram_gb < model_size_gb * 0.5`, while `_get_config_for_level` records
`estimated_memory_gb = model_size_gb * 0.5` for `QuantizationLevel.INT4`.

`QuantizationLevel.INT2` is the level that was meant to go here. It is declared in
the enum, it has a complete entry in `_get_config_for_level`
(`estimated_memory_gb = model_size_gb * 0.25`, `requires_calibration=True`), and
the rest of the codebase already supports it end-to-end
(`quantization_mixin._create_2bit_config`, the `"2bit"` branch in
`quantization_config_mixin`, the `vram_2bit_gb` entries in `provider_config`).
It is simply never selectable through the automatic path.

Each rung otherwise selects the level whose own memory estimate fits the VRAM
gate, so `INT2` (0.25×) is the natural occupant of the sub-0.5× branch.

### Fix

One line: the `else` branch selects `QuantizationLevel.INT2`.

### Verification

No hardware needed. Both variants of the function were cut out of the real file
(`git show HEAD:…` for "before", the patched worktree for "after"; the bodies are
extracted with `ast.get_source_segment`, never re-typed) and executed against a
stub `HardwareProfile` over a grid of 8 model sizes × 15 `vram / model_size`
ratios:

```
cells: 120   unchanged: 72   changed: 48
```

The 48 changed cells are **exactly** the cells with `vram < 0.5 × model_size` —
i.e. only the branch this patch touches. Sample rows:

| model_size_gb | vram/size | before | after |
|---|---|---|---|
| 7.0 | 0.49 | `('4bit', 3.5, calib=False)` | `('2bit', 1.75, calib=True)` |
| 7.0 | 0.50 | `('4bit', 3.5, calib=False)` | `('4bit', 3.5, calib=False)` (unchanged) |
| 70.0 | 0.10 | `('4bit', 35.0, calib=False)` | `('2bit', 17.5, calib=True)` |

Reachability of the enum member, over that same grid:

```
before  INT2 selectable: False
after   INT2 selectable: True
```

And the explicit `preferred_level=` path is untouched for every enum member:

```
preferred=NONE     -> NONE     SAME
preferred=FLOAT16  -> FLOAT16  SAME
preferred=BFLOAT16 -> BFLOAT16 SAME
preferred=INT8     -> INT8     SAME
preferred=INT4     -> INT4     SAME
preferred=INT2     -> INT2     SAME
```

No formatting change is required — the replaced call is the same shape as the one
it mirrors and stays inside `black`'s configured `line-length = 79`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
